### PR TITLE
Add a missing step to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ appengine-java-vm-runtime
 Complete code source of the Google App Engine [Java Managed VM](https://cloud.google.com/appengine/docs/managed-vms/) Docker image.
 It has 2 Java libraries, one generic for default servlets, filters and App Engine management, and one which is Jetty 9.x specific for Session management, App Engine APIs hook, and user login.
 
-The Java librairies are pushed to Maven Central, and used by the [docker/Dockerfile](docker/Dockerfile) that build the image. To use the image, you need to build it:
+The Java libraries are pushed to Maven Central, and used by the [docker/Dockerfile](docker/Dockerfile) that build the image. To use the image, you need to build it:
 
        git clone https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime.git
        cd appengine-java-vm-runtime
        mvn clean install
-       cp appengine-jetty-managed-runtime/target/appengine-jetty-managed-runtime*.jar docker/lib//ext/appengine-jetty-managed-runtime.jar
+       mkdir -p docker/lib/ext
+       cp appengine-jetty-managed-runtime/target/appengine-jetty-managed-runtime*.jar docker/lib/ext/appengine-jetty-managed-runtime.jar
        cp appengine-managed-runtime/target/appengine-managed-runtime*.jar docker/lib/ext/appengine-managed-runtime.jar
        cd docker
        docker build -t myimage .
@@ -18,7 +19,7 @@ Then, for a Java Web Application Archive, put a Dockerfile at the top directory 
 
       FROM myimage
       ADD . /app
-      
-Then, you can run this App Engine Managed VM container via the Cloud SDK [https://cloud.google.com/appengine/docs/java/managed-vms/](https://cloud.google.com/appengine/docs/java/managed-vms/) 
+
+Then, you can run this App Engine Managed VM container via the Cloud SDK [https://cloud.google.com/appengine/docs/java/managed-vms/](https://cloud.google.com/appengine/docs/java/managed-vms/)
 
 Enjoy...


### PR DESCRIPTION
This pull request fixes a minor issue in the `README`: It's missing a step to create the `docker/lib/ext` directory, which doesn't exist in a fresh copy of the repo.

I also corrected two minor typos and removed some trailing whitespace.