### PR TITLE
Implement changing session id

### DIFF
--- a/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
+++ b/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
@@ -83,12 +83,6 @@ public class SessionManager extends AbstractSessionManager {
   public static class SessionIdManager extends HashSessionIdManager {
 
     
-    /**
-     * NOTE this breaks the standard jetty contract that there is only 1
-     * SessionIdManager per server instance, and 1 SessionManager instance
-     * per context.
-     * @param manager
-     */
     public SessionIdManager() {
       super(new SecureRandom());
     }

--- a/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
+++ b/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
@@ -82,8 +82,6 @@ public class SessionManager extends AbstractSessionManager {
   // SecureRandom class.
   public static class SessionIdManager extends HashSessionIdManager {
 
-    private SessionManager manager;
-    
     
     /**
      * NOTE this breaks the standard jetty contract that there is only 1
@@ -91,9 +89,8 @@ public class SessionManager extends AbstractSessionManager {
      * per context.
      * @param manager
      */
-    public SessionIdManager(SessionManager manager) {
+    public SessionIdManager() {
       super(new SecureRandom());
-      this.manager = manager;
     }
 
     /**
@@ -122,18 +119,7 @@ public class SessionManager extends AbstractSessionManager {
       logger.fine("Created a random session identifier: " + id);
       return id;
     }
-    
-    
-    @Override
-    public void renewSessionId(String oldClusterId, String oldNodeId, HttpServletRequest request) {
-      // generate a new id
-      String newClusterId = newSessionId(request.hashCode());
-
-      // tell session manager to update the id
-      manager.renewSessionId(oldClusterId, oldNodeId, newClusterId, getNodeId(newClusterId, request));
-    }
-
-
+   
   }
 
   /**
@@ -406,7 +392,7 @@ public class SessionManager extends AbstractSessionManager {
     
     //NOTE: this breaks the standard jetty contract that a single server has a single SessionIdManager
     //but there is 1 SessionManager per context.
-    _sessionIdManager = new SessionIdManager(this);
+    _sessionIdManager = new SessionIdManager();
   }
 
   @Override

--- a/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
+++ b/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
@@ -25,15 +25,11 @@ import com.google.apphosting.api.DeadlineExceededException;
 import com.google.apphosting.runtime.SessionData;
 import com.google.apphosting.runtime.SessionStore;
 
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.SessionIdManager;
-import org.eclipse.jetty.server.handler.ContextHandler;
+
 import org.eclipse.jetty.server.session.AbstractSession;
 import org.eclipse.jetty.server.session.AbstractSessionManager;
 import org.eclipse.jetty.server.session.HashSessionIdManager;
-import org.eclipse.jetty.server.session.SessionHandler;
-import org.eclipse.jetty.util.component.LifeCycle.Listener;
+
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -50,7 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+
 
 /**
  * Implements the Jetty {@link AbstractSessionManager} and, as an

--- a/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
+++ b/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/runtime/jetty9/SessionManager.java
@@ -46,6 +46,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionIdListener;
 
 
 /**
@@ -182,6 +184,9 @@ public class SessionManager extends AbstractSessionManager {
     
     @Override
     public void renewId(HttpServletRequest request) {
+      
+      String oldId = getClusterId();
+      
       //remove session with the old from storage
       deleteSession();
       
@@ -197,7 +202,9 @@ public class SessionManager extends AbstractSessionManager {
       //save the session with the new id
       save(true);
       
-      setIdChanged(true);   
+      setIdChanged(true);  
+      
+      ((SessionManager)getSessionManager()).callSessionIdListeners(this, oldId);
     }
     
    
@@ -532,5 +539,19 @@ public class SessionManager extends AbstractSessionManager {
     
   }
 
+  
+  /**
+   * Call any session id listeners registered.
+   * Usually done by renewSessionId() method, but that is not used in appengine.
+   * @param session
+   * @param oldId
+   */
+  public void callSessionIdListeners (AbstractSession session, String oldId) {
+    HttpSessionEvent event = new HttpSessionEvent(session);
+    for (HttpSessionIdListener l:_sessionIdListeners)
+    {
+        l.sessionIdChanged(event, oldId);
+    }
+  }
   
 }

--- a/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/runtime/jetty9/SessionManagerTest.java
+++ b/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/runtime/jetty9/SessionManagerTest.java
@@ -206,7 +206,7 @@ public class SessionManagerTest extends TestCase {
   public void testIdGeneration() {
     long timestamp = System.currentTimeMillis();
 
-    SessionManager.SessionIdManager idManager = new SessionManager.SessionIdManager(manager);
+    SessionManager.SessionIdManager idManager = new SessionManager.SessionIdManager();
     HttpServletRequest mockRequest = makeMockRequest(false);
     replay(mockRequest);
     String sessionid = idManager.newSessionId(mockRequest, timestamp);

--- a/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/runtime/jetty9/SessionManagerTest.java
+++ b/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/runtime/jetty9/SessionManagerTest.java
@@ -45,6 +45,8 @@ import com.google.apphosting.api.ApiProxy.LogRecord;
 import com.google.apphosting.runtime.DatastoreSessionStore;
 import com.google.apphosting.runtime.DeferredDatastoreSessionStore;
 import com.google.apphosting.runtime.MemcacheSessionStore;
+import com.google.apphosting.runtime.SessionData;
+import com.google.apphosting.runtime.SessionManagerUtil;
 import com.google.apphosting.runtime.SessionStore;
 import com.google.apphosting.runtime.jetty9.SessionManager.AppEngineSession;
 
@@ -204,7 +206,7 @@ public class SessionManagerTest extends TestCase {
   public void testIdGeneration() {
     long timestamp = System.currentTimeMillis();
 
-    SessionManager.SessionIdManager idManager = new SessionManager.SessionIdManager();
+    SessionManager.SessionIdManager idManager = new SessionManager.SessionIdManager(manager);
     HttpServletRequest mockRequest = makeMockRequest(false);
     replay(mockRequest);
     String sessionid = idManager.newSessionId(mockRequest, timestamp);
@@ -267,6 +269,50 @@ public class SessionManagerTest extends TestCase {
     assertEquals(session.getId(), session2.getId());
     assertEquals("bar", session2.getAttribute("foo"));
   }
+  
+  
+  public void testRenewSessionId() throws Exception {
+    HttpServletRequest request = makeMockRequest(true);
+    replay(request);
+    AppEngineSession session = manager.newSession(request);
+    session.setAttribute("foo", "bar");
+    session.save();
+    String oldId = session.getId();   
+    byte[] bytes = (byte[])memcache.get(SessionManager.SESSION_PREFIX + oldId);
+    assertNotNull(bytes);
+    SessionData data = (SessionData)SessionManagerUtil.deserialize(bytes);
+    assertEquals("bar", data.getValueMap().get("foo"));
+    
+    //renew session id 
+    session.renewId(request);
+
+    //Ensure we deleted the session with the old id
+    AppEngineSession sessionx = manager.getSession(oldId);
+    assertNull(sessionx);
+    assertNull(memcache.get(SessionManager.SESSION_PREFIX + oldId));
+    
+    //Ensure we changed the id
+    String newId = session.getId(); 
+    assertNotSame(oldId, newId);
+    
+    //Ensure we stored the session with the new id
+    AppEngineSession session2 = manager.getSession(newId);
+    assertNotSame(session, session2);
+    assertEquals("bar", session2.getAttribute("foo"));   
+    bytes = (byte[])memcache.get(SessionManager.SESSION_PREFIX + newId);
+    assertNotNull(bytes);
+    data = (SessionData)SessionManagerUtil.deserialize(bytes);
+    assertEquals("bar", data.getValueMap().get("foo"));
+    
+    //Test we can store attributes
+    session2.setAttribute("one", "two");
+    session2.save();
+    bytes = (byte[])memcache.get(SessionManager.SESSION_PREFIX + newId);
+    assertNotNull(bytes);
+    data = (SessionData)SessionManagerUtil.deserialize(bytes);
+    assertEquals("two", data.getValueMap().get("one"));
+  }
+  
 
   private AppEngineSession createSession() {
     NamespaceManager.set(startNamespace());


### PR DESCRIPTION
The Session.renewId(Request) method has been implemented for appengine compat sessions. This makes the Request.changeSessionId() method now work for appengine.

The only piece missing is the automatic changing of session id when a user authenticates - not sure that is appropriate as appengine does not use sessions as part of the authentication mechanism.