### PR TITLE
Set ENTRYPOINT to execute java.

### DIFF
--- a/gce-debian-openjdk/pom.xml
+++ b/gce-debian-openjdk/pom.xml
@@ -42,12 +42,12 @@
             <goals>
               <goal>build</goal>
             </goals>
-	    <configuration>
-	      <imageName>gce-debian-openjdk:8-jre</imageName>
-	      <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
-	    </configuration>
-	  </execution>
-	</executions>
+            <configuration>
+              <imageName>gce-debian-openjdk:8-jre</imageName>
+              <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/gce-debian-openjdk/src/main/docker/Dockerfile
+++ b/gce-debian-openjdk/src/main/docker/Dockerfile
@@ -30,5 +30,4 @@ rm /var/lib/apt/lists/*_*
 # workaround for https://bugs.debian.org/775775
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
-CMD ["bash"]
-ENTRYPOINT []
+ENTRYPOINT [ "/usr/bin/java" ]


### PR DESCRIPTION
This allows downstream images to just use CMD to run vanilla Java code.
Alternatively, they can override ENTRYPOINT to automatically run framework code.