### PR TITLE
Update README To Just use buildimage script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,8 @@ It has 2 Java libraries, one generic for default servlets, filters and App Engin
 
 The Java libraries are pushed to Maven Central, and used by the [docker/Dockerfile](docker/Dockerfile) that build the image. To use the image, you need to build it:
 
-       git clone https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime.git
-       cd appengine-java-vm-runtime
-       mvn clean install
-       mkdir -p docker/lib/ext
-       cp appengine-jetty-managed-runtime/target/appengine-jetty-managed-runtime*.jar docker/lib/ext/appengine-jetty-managed-runtime.jar
-       cp appengine-managed-runtime/target/appengine-managed-runtime*.jar docker/lib/ext/appengine-managed-runtime.jar
-       cd docker
-       docker build -t myimage .
+
+       ./buildimage.sh
 
 Then, for a Java Web Application Archive, put a Dockerfile at the top directory (for example, with a Maven build, create the Dockerfile in ./src/main/webapp directory) and from this Docker image, just add your Web Application content into the /app of the container.
 


### PR DESCRIPTION
Fix for issue #79. One possible suggestion to keep README working is just to suggest the script. 