### PR TITLE
Do not set the ENTRYPOINT for docker image

### DIFF
--- a/gce-debian-openjdk/src/main/docker/Dockerfile
+++ b/gce-debian-openjdk/src/main/docker/Dockerfile
@@ -29,5 +29,3 @@ rm /var/lib/apt/lists/*_*
 
 # workaround for https://bugs.debian.org/775775
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-
-ENTRYPOINT [ "/usr/bin/java" ]


### PR DESCRIPTION
Undoing the change to set the default ENTRYPOINT.
Leaving both ENTRYPOINT and CMD unset to match Docker's OpenJDK image.