### PR TITLE
Added ALPN support to gce-debian-openjdk #82

### DIFF
--- a/appengine-jetty-managed-runtime/src/main/docker/Dockerfile
+++ b/appengine-jetty-managed-runtime/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i 's/^\([a-zA-Z\.]*=\).*/#\1(see gae.ini)/' start.d/server.ini \
  && rm -f start.d/setuid.ini start.d/deploy.ini \
  && java -jar $JETTY_HOME/start.jar --add-to-startd=gae,gae-deploy \
  && java -jar $JETTY_HOME/start.jar --dry-run \
-  | sed 's/^.*java /& ${JAVA_OPTS} ${DBG_AGENT} ${PROF_AGENT} -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE} /' > jetty_cmd.sh \
+  | sed 's/^.*java /& ${JAVA_OPTS} ${ALPN_BOOT} ${DBG_AGENT} ${PROF_AGENT} -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE} /' > jetty_cmd.sh \
  && chmod +x /var/lib/jetty/jetty_run.sh
     
 WORKDIR /app

--- a/appengine-jetty-managed-runtime/src/main/docker/jetty_run.sh
+++ b/appengine-jetty-managed-runtime/src/main/docker/jetty_run.sh
@@ -17,6 +17,11 @@ HEAP_SIZE=$(awk -v frac=$HEAP_SIZE_FRAC -v res=$RAM_RESERVED_MB /MemTotal/'{
   print int($2/1024*frac-res) "M" } ' /proc/meminfo)
 echo "Info: Limiting Java heap size to: $HEAP_SIZE"
 
+ALPN_BOOT=
+if [[ -n "$ALPN_ENABLE" ]]; then
+  ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
+fi
+
 DBG_AGENT=
 if [[ "$GAE_PARTITION" = "dev" ]]; then
   if [[ -n "$DBG_ENABLE" ]]; then
@@ -25,12 +30,12 @@ if [[ "$GAE_PARTITION" = "dev" ]]; then
     DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT}"
   fi
 else
-  DBG_AGENT="$( /home/vmagent/cdbg/format-env-appengine-vm.sh )"
+  DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
 fi
 
 PROF_AGENT=
 if [[ -n "${CPROF_ENABLE}" ]]; then
-  PROF_AGENT="$( /home/vmagent/cprof/format-env-appengine-vm.sh )"
+  PROF_AGENT="$( /opt/cprof/format-env-appengine-vm.sh )"
 fi
 
 # use generated fast cli:

--- a/gce-debian-openjdk/pom.xml
+++ b/gce-debian-openjdk/pom.xml
@@ -28,8 +28,33 @@
   <artifactId>gce-debian-openjdk</artifactId>
   <packaging>pom</packaging>
 
+  <properties>
+    <alpn.version>8.1.5.v20150921</alpn.version>
+  </properties>
+
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <id>generate-docker</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <target>
+	        <copy todir="${project.build.directory}/generated-sources/docker">
+		  <fileset dir="${project.basedir}/src/main/docker"/>
+		</copy>
+		<replace file="${project.build.directory}/generated-sources/docker/Dockerfile" token="@@alpn.version@@" value="${alpn.version}"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>docker-maven-plugin</artifactId>
@@ -42,7 +67,7 @@
             </goals>
             <configuration>
               <imageName>gce-debian-openjdk:8-jre</imageName>
-              <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+              <dockerDirectory>${project.basedir}/target/generated-sources/docker</dockerDirectory>
             </configuration>
           </execution>
 	  <execution>
@@ -63,4 +88,3 @@
     </plugins>
   </build>
 </project>
-

--- a/gce-debian-openjdk/src/main/docker/Dockerfile
+++ b/gce-debian-openjdk/src/main/docker/Dockerfile
@@ -32,8 +32,12 @@ rm /var/lib/apt/lists/*_*
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # Add the cloud debugger and profiler libraries
-ADD https://storage.googleapis.com/cloud-debugger/appengine-java/current/cdbg_java_agent.tar.gz /home/vmagent/cdbg/
-ADD https://storage.googleapis.com/cloud-profiler/appengine-java/current/cloud_profiler_java_agent.tar.gz /home/vmagent/cprof/
-RUN tar Cxfvz /home/vmagent/cdbg /home/vmagent/cdbg/cdbg_java_agent.tar.gz \
- && tar Cxfvz /home/vmagent/cprof /home/vmagent/cprof/cloud_profiler_java_agent.tar.gz \
- && rm /home/vmagent/cdbg/cdbg_java_agent.tar.gz /home/vmagent/cprof/cloud_profiler_java_agent.tar.gz
+ADD https://storage.googleapis.com/cloud-debugger/appengine-java/current/cdbg_java_agent.tar.gz /opt/cdbg/
+ADD https://storage.googleapis.com/cloud-profiler/appengine-java/current/cloud_profiler_java_agent.tar.gz /opt/cprof/
+ADD ./alpn /opt/alpn
+ADD http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/@@alpn.version@@/alpn-boot-@@alpn.version@@.jar /opt/alpn/
+RUN tar Cxfvz /opt/cdbg /opt/cdbg/cdbg_java_agent.tar.gz \
+ && tar Cxfvz /opt/cprof /opt/cprof/cloud_profiler_java_agent.tar.gz \
+ && rm /opt/cdbg/cdbg_java_agent.tar.gz /opt/cprof/cloud_profiler_java_agent.tar.gz \
+ && ln -s /opt/alpn/alpn-boot-8.1.5.v20150921.jar /opt/alpn/alpn-boot.jar \
+ && chmod +x /opt/alpn/format-env-appengine-vm.sh

--- a/gce-debian-openjdk/src/main/docker/alpn/format-env-appengine-vm.sh
+++ b/gce-debian-openjdk/src/main/docker/alpn/format-env-appengine-vm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# Formats Java command line option to enable ALPN
+#
+# The script assumes that AppEngine specific environment variables are set.
+#
+# Usage example:
+#     java $( /usr/local/alpn/format-env-appengine-vm.sh ) -cp ...
+#
+
+if [[ -n "${ALPN_DISABLE}" ]]; then
+  >&2 echo "ALPN_DISABLE is set, ALPN will not be loaded"
+  exit
+fi
+
+ALPN_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ARGS="-Xbootclasspath/p:${ALPN_ROOT}/alpn-boot.jar"
+
+echo "${ARGS}"
+

--- a/gce-jetty/src/main/docker/Dockerfile
+++ b/gce-jetty/src/main/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN mv /usr/local/jetty-distribution-* $JETTY_HOME \
 ENV JETTY_BASE /var/lib/jetty
 RUN mkdir -p $JETTY_BASE
 WORKDIR $JETTY_BASE
+ADD gce-alpn.mod modules/
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=http,deploy,jsp,jstl,setuid \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \

--- a/gce-jetty/src/main/docker/docker-entrypoint.bash
+++ b/gce-jetty/src/main/docker/docker-entrypoint.bash
@@ -1,25 +1,30 @@
 #!/bin/bash
 
 if ! type "$1" &>/dev/null; then
-    DBG_AGENT=
-    if [[ -n "$DBG_ENABLE" ]]; then
-      if [[ "$GAE_PARTITION" = "dev" ]]; then
-        DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT:-5005}"
-      else
-        DBG_AGENT="$( /home/vmagent/cdbg/format-env-appengine-vm.sh )"
-      fi
-    fi
+  ALPN_BOOT=
+  if [[ -n "$ALPN_ENABLE" ]]; then
+    ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
+  fi
 
-    PROF_AGENT=
-    if [[ -n "${CPROF_ENABLE}" ]]; then
-      if [[ "$GAE_PARTITION" = "dev" ]]; then
-        PROF_AGENT=
-      else
-        PROF_AGENT="$( /home/vmagent/cprof/format-env-appengine-vm.sh )"
-      fi
+  DBG_AGENT=
+  if [[ -n "$DBG_ENABLE" ]]; then
+    if [[ "$GAE_PARTITION" = "dev" ]]; then
+      DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT:-5005}"
+    else
+      DBG_AGENT="$( /home/vmagent/cdbg/format-env-appengine-vm.sh )"
     fi
+  fi
 
-    set -- java $DBG_AGENT $PROF_AGENT -jar "-Djava.io.tmpdir=$TMPDIR" "-Djetty.base=$JETTY_BASE" "$JETTY_HOME/start.jar" "$@"
+  PROF_AGENT=
+  if [[ -n "${CPROF_ENABLE}" ]]; then
+    if [[ "$GAE_PARTITION" = "dev" ]]; then
+      PROF_AGENT=
+    else
+      PROF_AGENT="$( /home/vmagent/cprof/format-env-appengine-vm.sh )"
+    fi
+  fi
+
+  set -- java $ALPN_BOOT $DBG_AGENT $PROF_AGENT -jar "-Djava.io.tmpdir=$TMPDIR" "-Djetty.base=$JETTY_BASE" "$JETTY_HOME/start.jar" "$@"
 fi
 
 exec "$@"

--- a/gce-jetty/src/main/docker/gce-alpn.mod
+++ b/gce-jetty/src/main/docker/gce-alpn.mod
@@ -1,0 +1,37 @@
+# ALPN can be proved by the gce-debian-openjdk image if the ALPN_ENABLE 
+# environment variable is set.   
+#
+# This module is an alternate to the standard jetty alpn.mod that uses
+# the gce provided ALPN implementation. It should be explicitly enabled
+# prior http2 or any module that depends on alpn.
+
+[name]
+alpn
+
+[depend]
+ssl
+
+[lib]
+lib/jetty-alpn-client-${jetty.version}.jar
+lib/jetty-alpn-server-${jetty.version}.jar
+
+[xml]
+etc/jetty-alpn.xml
+
+[files]
+/opt/alpn/
+lib/
+lib/alpn/
+
+[ini-template]
+## Overrides the order protocols are chosen by the server.
+## The default order is that specified by the order of the
+## modules declared in start.ini.
+# jetty.alpn.protocols=h2-16,http/1.1
+
+## Specifies what protocol to use when negotiation fails.
+# jetty.alpn.defaultProtocol=http/1.1
+
+## ALPN debug logging on System.err
+# jetty.alpn.debug=false
+


### PR DESCRIPTION
Issue #82
Moved gdbg, gprof and alpn to /opt
Added /opt/alpn/format-env-appengine-vm.sh create ALPN java args
Added $JETTY_BASE/modules/gce-alpn.mod to avoid downloading jetty ALPN

The env variable ALPN_ENABLE and ALPN_DISABLE follow the same pattern as
used for cdbg and cprof.

If ALPN_ENABLE is set, then the jetty_run.sh and docker-entrypoint.bash scripts
will call /opt/alpn/format-env-appengine-vm.sh.   That script will look for
ALPN_DISABLE and if not set, will produce arguments for the boot classpath.