### PR TITLE
Upgraded to openssl 1.02

### DIFF
--- a/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeTestBase.java
+++ b/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeTestBase.java
@@ -55,7 +55,7 @@ public  class VmRuntimeTestBase extends TestCase {
 
 
   // Wait at the most 30 seconds for Jetty to come up.
-  private static final int JETTY_START_DELAY = 30;
+  private static final int JETTY_START_DELAY = 45;
 
   public static final String PROJECT = "google.com:test-project";
   public static final String PARTITION = "testpartition";

--- a/gke-debian-openjdk/src/main/docker/Dockerfile
+++ b/gke-debian-openjdk/src/main/docker/Dockerfile
@@ -31,6 +31,12 @@ rm /var/lib/apt/lists/*_*
 # workaround for https://bugs.debian.org/775775
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
+# Upgrade to OpenSSL 1.0.2
+ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/
+ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/openssl_1.0.2d-3_amd64.deb /tmp/
+RUN dpkg -i /tmp/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/openssl_1.0.2d-3_amd64.deb \
+ && rm /tmp/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/openssl_1.0.2d-3_amd64.deb
+
 # Add the cloud debugger and profiler libraries
 ADD https://storage.googleapis.com/cloud-debugger/appengine-java/current/cdbg_java_agent.tar.gz /opt/cdbg/
 ADD https://storage.googleapis.com/cloud-profiler/appengine-java/current/cloud_profiler_java_agent.tar.gz /opt/cprof/


### PR DESCRIPTION
For issue #115  
The debs required turned out to be: 
```
ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/
ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/openssl_1.0.2d-3_amd64.deb /tmp/
```