### PR TITLE
improve README for gke images

### DIFF
--- a/appengine-jetty-managed-runtime/src/main/docker/jetty_run.sh
+++ b/appengine-jetty-managed-runtime/src/main/docker/jetty_run.sh
@@ -17,27 +17,9 @@ HEAP_SIZE=$(awk -v frac=$HEAP_SIZE_FRAC -v res=$RAM_RESERVED_MB /MemTotal/'{
   print int($2/1024*frac-res) "M" } ' /proc/meminfo)
 echo "Info: Limiting Java heap size to: $HEAP_SIZE"
 
-ALPN_BOOT=
-if [[ -n "$ALPN_ENABLE" ]]; then
-  ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
-fi
-
-DBG_AGENT=
-if [[ "$GAE_PARTITION" = "dev" ]]; then
-  if [[ -n "$DBG_ENABLE" ]]; then
-    echo "Running locally and DBG_ENABLE is set, enabling standard Java debugger agent"
-    DBG_PORT=${DBG_PORT:-5005}
-    DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT}"
-  fi
-else
-  DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
-fi
-
-PROF_AGENT=
-if [[ -n "${CPROF_ENABLE}" ]]; then
-  PROF_AGENT="$( /opt/cprof/format-env-appengine-vm.sh )"
-fi
-
+# source the supported feature JVM arguments
+source /gke-env.bash
+  
 # use generated fast cli:
 cd /var/lib/jetty
 source /var/lib/jetty/jetty_cmd.sh

--- a/gke-debian-openjdk/README.md
+++ b/gke-debian-openjdk/README.md
@@ -1,17 +1,58 @@
-gke-debian-openjdk8
-=========================
+# gke-debian-openjdk8 Docker Image
 
-This project builds a Docker image for debian and openjdk8 is used as a base image for Google Computer Engine and 
+This project builds a Docker image for debian and openjdk8 is used as a base image for Google Container Engine and 
 Google App Engine [Java Managed VM](https://cloud.google.com/appengine/docs/managed-vms/) Docker images.
 
-To use the image, you need to build it:
+## Building the image
+To build the image you need git, docker and maven installed:
+```
+$ git clone https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime.git
+$ cd appengine-java-vm-runtime/gke-debian-openjdk8
+$ mvn clean install
+```
+The resulting image is called gke-debian-openjdk:8-jre 
 
-       git clone https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime.git
-       cd appengine-java-vm-runtime/gke-debian-openjdk8
-       mvn clean install
+## The Default Entry Point
+The default entrypoint will print the JDK version:
+```
+$ docker run gke-debian-openjdk:8-jre
+openjdk version "1.8.0_66-internal"
+OpenJDK Runtime Environment (build 1.8.0_66-internal-b17)
+OpenJDK 64-Bit Server VM (build 25.66-b17, mixed mode)
+```
 
-The resulting image is called gke-debian-openjdk8 and the default bash entrypoint can be run with
+Any arguments passed to the entry point that are not executable are treated as arguments to the java command:
+```
+$ docker run gke-debian-openjdk:8-jre -jar /usr/share/someapplication.jar
+```
 
-       docker run -it --rm gke-debian-openjdk8
+Any arguments passed to the entry point that are executable replace the default command, thus a shell could
+be run with:
+```
+> docker run -it --rm gke-debian-openjdk:8-jre bash
+root@c7b35e88ff93:/# 
+```
 
-Enjoy...
+## Entry Point Features
+The entry point for the gke-debian-openjdk image is [docker-entrypoint.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/gke-debian-openjdk/src/main/docker/docker-entrypoint.bash), which does the processing of the passed command line arguments to look for an executable alternative or arguments to the default command (java).
+
+If the default command (java) is used, then the entry point sources the [gke-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/gke-debian-openjdk/src/main/docker/gke-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
+
+| Feature        | directory    | Enable        | Disable        | JVM args      |
+|----------------|--------------|---------------|----------------|---------------|
+| ALPN           | /opt/alpn/   | $ALPN_ENABLE  | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Cloud Debugger | /opt/cdbg/   | $DBG_ENABLE   | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file |              | $TMPDIR       |                | $SET_TMP      |
+| Java options   |              | $JAVA_OPTS    |                | $JAVA_OPTS    |
+
+The command line executed is effectively (where $@ are the args passed into the 
+docker entry point):
+```
+java $ALPN_BOOT $DBG_AGENT $PROF_AGENT $SET_TMP $JAVA_OPTS "$@"
+```
+
+
+
+
+

--- a/gke-debian-openjdk/src/main/docker/docker-entrypoint.bash
+++ b/gke-debian-openjdk/src/main/docker/docker-entrypoint.bash
@@ -1,14 +1,23 @@
 #!/bin/bash
 
+# If the first argument is the java command
 if [ "java" = "$1" -o "$(which java)" = "$1" ] ; then
+  # ignore it as java is the default command
   shift
 fi
 
+# If the first argument is not executable
 if ! type "$1" &>/dev/null; then
+  # then treat all arguments as arguments to the java command
+  
+  # source the supported feature JVM arguments
   source /gke-env.bash
+  
+  # set the command line to java with the feature arguments and passed arguments
   set -- java $ALPN_BOOT $DBG_AGENT $PROF_AGENT $SET_TMP $JAVA_OPTS "$@"
 fi
 
+# exec the entry point arguments as a command
 exec "$@"
 
 

--- a/gke-debian-openjdk/src/main/docker/gke-env.bash
+++ b/gke-debian-openjdk/src/main/docker/gke-env.bash
@@ -7,9 +7,11 @@ fi
 DBG_AGENT=
 if [[ -n "$DBG_ENABLE" ]]; then
   if [[ "$GAE_PARTITION" = "dev" ]]; then
-    DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT:-5005}"
+    echo "Running locally and DBG_ENABLE is set, enabling standard Java debugger agent"
+    DBG_PORT=${DBG_PORT:-5005}
+    DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT}"
   else
-    DBG_AGENT="$( /home/vmagent/cdbg/format-env-appengine-vm.sh )"
+    DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
   fi
 fi
 
@@ -18,7 +20,7 @@ if [[ -n "${CPROF_ENABLE}" ]]; then
   if [[ "$GAE_PARTITION" = "dev" ]]; then
     PROF_AGENT=
   else
-    PROF_AGENT="$( /home/vmagent/cprof/format-env-appengine-vm.sh )"
+    PROF_AGENT="$( /opt/cprof/format-env-appengine-vm.sh )"
   fi
 fi
 

--- a/gke-jetty/README.md
+++ b/gke-jetty/README.md
@@ -11,8 +11,8 @@ the official [docker-jetty documentation](https://github.com/docker-library/docs
 should apply.
 
 ## Building the Jetty image
-To use the image, you need to build it:
-
+To build the image you need git, docker and maven installed and to have the gke-debian-openjdk:8-jre
+image available in your docker repository:
 ```console
 git clone https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime.git
 cd appengine-java-vm-runtime/gke-jetty
@@ -20,22 +20,23 @@ mvn clean install
 ```
 
 ## Running the Jetty image
-The resulting image is called gke-jetty-9.3 and can be run with:
+The resulting image is called gke-jetty:9.3.5.v20151012 (or the current jetty version as the label) 
+and can be run with:
 ```console
-docker run gke-jetty-9.3
+docker run gke-jetty:9.3.5.v20151012
 ```
 
 ## Configuring the Jetty image
 Arguments passed to the docker run command are passed to Jetty, so the 
 configuration of the jetty server can be seen with a command like:
 ```console
-docker run gke-jetty-9.3 --list-config
+docker run gke-jetty:9.3.5.v20151012 --list-config
 ```
 
 Alternate commands can also be passed to the docker run command, so the
 image can be explored with 
 ```console
-docker run t --rm gke-jetty-9.3 bash
+docker run t --rm gke-jetty:9.3.5.v20151012 bash
 ```
 
 To update the server configuration in a derived Docker image, the `Dockerfile` may
@@ -46,6 +47,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,stats
 ```
 Modules may be configured in a `Dockerfile` by editing the properties in the corresponding `/var/lib/jetty/start.d/*.mod` file or the module can be deactivated by removing that file.
 
+## GAE Managed VMs
 This image works with App Engine Managed VMs as a custom runtime.
 In order to use it, you need to build the image (let's call it `YOUR_BUILT_IMAGE`), (and optionally push it to a Docker registery like gcr.io). Then, you can add to any pure Java EE 7 Web Application projects these 2 configuration files next to the exploded WAR directory:
 
@@ -66,6 +68,34 @@ Once you have this configuration, you can use the Google Cloud SDK to deploy thi
 
      gcloud preview app deploy app.yaml
      
-     
+
+## Entry Point Features
+The entry point for the image is [docker-entrypoint.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/gke-jetty/src/main/docker/docker-entrypoint.bash), which does the processing of the passed command line arguments to look for an executable alternative or arguments to the default command (java).
+
+If the default command (java) is used, then the entry point sources the [gke-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/gke-debian-openjdk/src/main/docker/gke-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
+
+| Feature        | directory    | Enable        | Disable        | JVM args      |
+|----------------|--------------|---------------|----------------|---------------|
+| ALPN           | /opt/alpn/   | $ALPN_ENABLE  | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Cloud Debugger | /opt/cdbg/   | $DBG_ENABLE   | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file |              | $TMPDIR       |                | $SET_TMP      |
+| Java options   |              | $JAVA_OPTS    |                | $JAVA_OPTS    |
+
+The command line executed is effectively (where $@ are the args passed into the 
+docker entry point):
+```
+java $ALPN_BOOT \
+     $DBG_AGENT \
+     $PROF_AGENT \
+     $SET_TMP \
+     $JAVA_OPTS \
+     -Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar \
+     "$@"
+```
+
+
+
+
 
 Enjoy...

--- a/gke-jetty/src/main/docker/docker-entrypoint.bash
+++ b/gke-jetty/src/main/docker/docker-entrypoint.bash
@@ -1,15 +1,25 @@
 #!/bin/bash
 
-START_JETTY="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
+# default jetty arguments
+DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
+# If the passed arguments start with the java command
 if [ "java" = "$1" -o "$(which java)" = "$1" ] ; then
+  # ignore the java command as it is the default
   shift
-  START_JETTY=
+  # clear the default args, use the passed args
+  DEFAULT_ARGS=
 fi
 
+# If the first argument is not executable
 if ! type "$1" &>/dev/null; then
+  # then treat all arguments as arguments to the java command
+  
+  # source the supported feature JVM arguments
   source /gke-env.bash
-  set -- java $ALPN_BOOT $DBG_AGENT $PROF_AGENT $SET_TMP $JAVA_OPTS $START_JETTY "$@"
+  
+  # set the command line to java with the feature arguments and passed arguments
+  set -- java $ALPN_BOOT $DBG_AGENT $PROF_AGENT $SET_TMP $JAVA_OPTS $DEFAULT_ARGS "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Improve the documentation in the README for the GKE images.
This also contains comments and simplifications in the entry point slips.. which detected a bug in that the gke_env.sh script had not been fully updated for the /opt home for cdbg and cprof
