### PR TITLE
#143 Updated libssl dependency

### DIFF
--- a/gke-debian-openjdk/src/main/docker/Dockerfile
+++ b/gke-debian-openjdk/src/main/docker/Dockerfile
@@ -32,10 +32,10 @@ rm /var/lib/apt/lists/*_*
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # Upgrade to OpenSSL 1.0.2
-ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/
-ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/openssl_1.0.2d-3_amd64.deb /tmp/
-RUN dpkg -i /tmp/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/openssl_1.0.2d-3_amd64.deb \
- && rm /tmp/libssl1.0.2_1.0.2d-3_amd64.deb /tmp/openssl_1.0.2d-3_amd64.deb
+ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2e-1_amd64.deb /tmp/
+ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/openssl_1.0.2e-1_amd64.deb /tmp/
+RUN dpkg -i /tmp/libssl1.0.2_1.0.2e-1_amd64.deb /tmp/openssl_1.0.2e-1_amd64.deb \
+ && rm /tmp/libssl1.0.2_1.0.2e-1_amd64.deb /tmp/openssl_1.0.2e-1_amd64.deb
 
 # Add the cloud debugger and profiler libraries
 ADD https://storage.googleapis.com/cloud-debugger/appengine-java/current/cdbg_java_agent.tar.gz /opt/cdbg/


### PR DESCRIPTION
Temporary fix for #143 to update to latest libssl version.   But issue should be left open until a durable store for the debs is found/created