### PR TITLE
Issue #166 - Adding API call logging

### DIFF
--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/RPCFailedStatusException.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/RPCFailedStatusException.java
@@ -1,0 +1,16 @@
+package com.google.apphosting.vmruntime;
+
+import com.google.apphosting.api.ApiProxy;
+
+public class RPCFailedStatusException extends ApiProxy.RPCFailedException {
+  private final int statusCode;
+  public RPCFailedStatusException(String packageName, String methodName, int statusCode)
+  {
+    super(packageName, methodName);
+    this.statusCode = statusCode;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,10 @@
-## Customize the Circle CI test machine
+## Customize the test machine
 machine:
  java:
   version: oraclejdk8
+
+ services:
+  - docker
 
 ## Prevent mvn dependency:resolve failing for intra-dependencies
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,7 @@
-## Customize the test machine
+## Customize the Circle CI test machine
 machine:
  java:
   version: oraclejdk8
-
- services:
-  - docker
 
 ## Prevent mvn dependency:resolve failing for intra-dependencies
 dependencies:


### PR DESCRIPTION
Adding info level API call logging using format from python.
Bumps up to warning level for API call failures.

Introduces `RPCFailedStatusException` to allow passing of failed api call status code knowledge.