### PR TITLE
Issue #143 - Use (sid) to obtain libssl & openssl

### DIFF
--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -35,14 +35,12 @@ ADD sid.list /etc/apt/sources.list.d/
 RUN apt-get -y update \
  && apt-get -y -q --no-install-recommends install \
     libssl1.0.2 \
-    openssl
-
+    openssl \
 # Cleanup sid references
-RUN rm /etc/apt/sources.list.d/sid.list \
- && apt-get -y update
-
+ && rm /etc/apt/sources.list.d/sid.list \
+ && apt-get -y update \
 # Cleanup apt-get temporary files
-RUN apt-get -y -q upgrade \
+ && apt-get -y -q upgrade \
  && apt-get -y -q autoremove
 
 # Add the cloud debugger and profiler libraries

--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -30,12 +30,19 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 # workaround for https://bugs.debian.org/775775
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
-# Upgrade to OpenSSL 1.0.2
-ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2f-2_amd64.deb /tmp/
-ADD http://ftp.us.debian.org/debian/pool/main/o/openssl/openssl_1.0.2f-2_amd64.deb /tmp/
-RUN dpkg -i /tmp/libssl1.0.2_1.0.2f-2_amd64.deb /tmp/openssl_1.0.2f-2_amd64.deb \
- && rm /tmp/libssl1.0.2_1.0.2f-2_amd64.deb /tmp/openssl_1.0.2f-2_amd64.deb \
- && apt-get -y -q upgrade \
+# Upgrade to OpenSSL 1.0.2 (via sid)
+ADD sid.list /etc/apt/sources.list.d/
+RUN apt-get -y update \
+ && apt-get -y -q --no-install-recommends install \
+    libssl1.0.2 \
+    openssl
+
+# Cleanup sid references
+RUN rm /etc/apt/sources.list.d/sid.list \
+ && apt-get -y update
+
+# Cleanup apt-get temporary files
+RUN apt-get -y -q upgrade \
  && apt-get -y -q autoremove
 
 # Add the cloud debugger and profiler libraries

--- a/openjdk8/src/main/docker/sid.list
+++ b/openjdk8/src/main/docker/sid.list
@@ -1,0 +1,1 @@
+deb http://ftp.us.debian.org/debian sid main


### PR DESCRIPTION
- Fix for the constantly changing libssl reference.
  Will temporarily install the (sid) apt repository,
  then install libssl1.0.2 and openssl only,
  removing the sid repository afterwords.

This is a speculative fix, and if you follow the build you'll see that it only adds those dependencies, but it somehow feels dirty to do it this way.