### PR TITLE
Fix #186 to use correct webdefault.xml

### DIFF
--- a/appengine-jetty-managed-runtime/src/main/docker/webapps/root.xml
+++ b/appengine-jetty-managed-runtime/src/main/docker/webapps/root.xml
@@ -22,7 +22,7 @@
     <SystemProperty name="jetty_parent_classloader" default="false"/>
   </Set>
   <Set name="defaultsDescriptor">
-    <SystemProperty name="jetty.home" default="."/>/etc/webdefault.xml
+    <SystemProperty name="jetty.base" default="."/>/etc/webdefault.xml
   </Set>
     <!-- Allow directory symbolic links  -->
   <!--Call name="addAliasCheck">


### PR DESCRIPTION
Fix for  #186. root.xml was referring to etc/webdefault.xml in jetty.home instead of jetty.base.