### PR TITLE
Explode WAR into $JETTY_BASE/webapps/root

### DIFF
--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
  && ln -s $JETTY_BASE/webapps/root /app \
- && touch $JETTY_BASE/webapps/root.xml
+ && touch $JETTY_BASE/webapps/root.war
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -36,9 +36,11 @@ ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
+ && mkdir $JETTY_BASE/webapps/root \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
- && ln -s $JETTY_BASE/webapps/root /app
+ && ln -s $JETTY_BASE/webapps/root /app \
+ && touch $JETTY_BASE/webapps/root.xml
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -36,7 +36,7 @@ ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
- && mkdir $JETTY_BASE/webapps/root \
+ && mkdir -p $JETTY_BASE/webapps/root \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
  && ln -s $JETTY_BASE/webapps/root /app \

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
  && ln -s $JETTY_BASE/webapps/root /app \
- && touch $JETTY_BASE/webapps/root.war
+ && touch --date '1970/01/01' $JETTY_BASE/webapps/root
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /


### PR DESCRIPTION
Following the discussion in #211, we make Jetty explode `root.war` into `$JETTY_BASE/webapps/root-exploded` in a proper way.