### PR TITLE
Enable Cloud (Stackdriver) Debugger on Java flex by default

### DIFF
--- a/jetty9/README.md
+++ b/jetty9/README.md
@@ -89,13 +89,13 @@ The entry point for the image is [docker-entrypoint.bash](https://github.com/Goo
 
 If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
 
-| Feature        | directory    | Enable        | Disable        | JVM args      |
-|----------------|--------------|---------------|----------------|---------------|
-| ALPN           | /opt/alpn/   | $ALPN_ENABLE  | $ALPN_DISABLE  | $ALPN_BOOT    |
-| Cloud Debugger | /opt/cdbg/   | $DBG_ENABLE   | $CDBG_DISABLE  | $DBG_AGENT    |
-| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE | $CPROF_DISABLE | $PROF_AGENT   |
-| Temporary file |              | $TMPDIR       |                | $SET_TMP      |
-| Java options   |              | $JAVA_OPTS    |                | $JAVA_OPTS    |
+| Feature        | directory    | Enable          | Disable        | JVM args      |
+|----------------|--------------|-----------------|----------------|---------------|
+| ALPN           | /opt/alpn/   | $ALPN_ENABLE    | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Cloud Debugger | /opt/cdbg/   | <on by default> | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE   | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file |              | $TMPDIR         |                | $SET_TMP      |
+| Java options   |              | $JAVA_OPTS      |                | $JAVA_OPTS    |
 
 The command line executed is effectively (where $@ are the args passed into the 
 docker entry point):

--- a/jetty9/README.md
+++ b/jetty9/README.md
@@ -89,13 +89,13 @@ The entry point for the image is [docker-entrypoint.bash](https://github.com/Goo
 
 If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
 
-| Feature        | directory    | Enable          | Disable        | JVM args      |
-|----------------|--------------|-----------------|----------------|---------------|
-| ALPN           | /opt/alpn/   | $ALPN_ENABLE    | $ALPN_DISABLE  | $ALPN_BOOT    |
-| Cloud Debugger | /opt/cdbg/   | <on by default> | $CDBG_DISABLE  | $DBG_AGENT    |
-| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE   | $CPROF_DISABLE | $PROF_AGENT   |
-| Temporary file |              | $TMPDIR         |                | $SET_TMP      |
-| Java options   |              | $JAVA_OPTS      |                | $JAVA_OPTS    |
+| Feature        | directory    | Enable            | Disable        | JVM args      |
+|----------------|--------------|-------------------|----------------|---------------|
+| ALPN           | /opt/alpn/   | $ALPN_ENABLE      | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Cloud Debugger | /opt/cdbg/   | \<on by default\> | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE     | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file |              | $TMPDIR           |                | $SET_TMP      |
+| Java options   |              | $JAVA_OPTS        |                | $JAVA_OPTS    |
 
 The command line executed is effectively (where $@ are the args passed into the 
 docker entry point):

--- a/jetty9/README.md
+++ b/jetty9/README.md
@@ -87,15 +87,15 @@ Once you have this configuration, you can use the Google Cloud SDK to deploy thi
 ## Entry Point Features
 The entry point for the image is [docker-entrypoint.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/jetty9/src/main/docker/docker-entrypoint.bash), which does the processing of the passed command line arguments to look for an executable alternative or arguments to the default command (java).
 
-If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
+If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Stackdriver Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
 
-| Feature        | directory    | Enable            | Disable        | JVM args      |
-|----------------|--------------|-------------------|----------------|---------------|
-| ALPN           | /opt/alpn/   | $ALPN_ENABLE      | $ALPN_DISABLE  | $ALPN_BOOT    |
-| Cloud Debugger | /opt/cdbg/   | \<on by default\> | $CDBG_DISABLE  | $DBG_AGENT    |
-| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE     | $CPROF_DISABLE | $PROF_AGENT   |
-| Temporary file |              | $TMPDIR           |                | $SET_TMP      |
-| Java options   |              | $JAVA_OPTS        |                | $JAVA_OPTS    |
+| Feature              | directory    | Enable            | Disable        | JVM args      |
+|----------------------|--------------|-------------------|----------------|---------------|
+| ALPN                 | /opt/alpn/   | $ALPN_ENABLE      | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Stackdriver Debugger | /opt/cdbg/   | \<on by default\> | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile        | /opt/cprof/  | $CPROF_ENABLE     | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file       |              | $TMPDIR           |                | $SET_TMP      |
+| Java options         |              | $JAVA_OPTS        |                | $JAVA_OPTS    |
 
 The command line executed is effectively (where $@ are the args passed into the 
 docker entry point):

--- a/openjdk8/README.md
+++ b/openjdk8/README.md
@@ -36,15 +36,15 @@ root@c7b35e88ff93:/#
 ## Entry Point Features
 The entry point for the openjdk8 image is [docker-entrypoint.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/docker-entrypoint.bash), which does the processing of the passed command line arguments to look for an executable alternative or arguments to the default command (java).
 
-If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
+If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Stackdriver Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
 
-| Feature        | directory    | Enable            | Disable        | JVM args      |
-|----------------|--------------|-------------------|----------------|---------------|
-| ALPN           | /opt/alpn/   | $ALPN_ENABLE      | $ALPN_DISABLE  | $ALPN_BOOT    |
-| Cloud Debugger | /opt/cdbg/   | \<on by default\> | $CDBG_DISABLE  | $DBG_AGENT    |
-| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE     | $CPROF_DISABLE | $PROF_AGENT   |
-| Temporary file |              | $TMPDIR           |                | $SET_TMP      |
-| Java options   |              | $JAVA_OPTS        |                | $JAVA_OPTS    |
+| Feature              | directory    | Enable            | Disable        | JVM args      |
+|----------------------|--------------|-------------------|----------------|---------------|
+| ALPN                 | /opt/alpn/   | $ALPN_ENABLE      | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Stackdriver Debugger | /opt/cdbg/   | \<on by default\> | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile        | /opt/cprof/  | $CPROF_ENABLE     | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file       |              | $TMPDIR           |                | $SET_TMP      |
+| Java options         |              | $JAVA_OPTS        |                | $JAVA_OPTS    |
 
 The command line executed is effectively (where $@ are the args passed into the 
 docker entry point):

--- a/openjdk8/README.md
+++ b/openjdk8/README.md
@@ -38,13 +38,13 @@ The entry point for the openjdk8 image is [docker-entrypoint.bash](https://githu
 
 If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
 
-| Feature        | directory    | Enable        | Disable        | JVM args      |
-|----------------|--------------|---------------|----------------|---------------|
-| ALPN           | /opt/alpn/   | $ALPN_ENABLE  | $ALPN_DISABLE  | $ALPN_BOOT    |
-| Cloud Debugger | /opt/cdbg/   | $DBG_ENABLE   | $CDBG_DISABLE  | $DBG_AGENT    |
-| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE | $CPROF_DISABLE | $PROF_AGENT   |
-| Temporary file |              | $TMPDIR       |                | $SET_TMP      |
-| Java options   |              | $JAVA_OPTS    |                | $JAVA_OPTS    |
+| Feature        | directory    | Enable          | Disable        | JVM args      |
+|----------------|--------------|-----------------|----------------|---------------|
+| ALPN           | /opt/alpn/   | $ALPN_ENABLE    | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Cloud Debugger | /opt/cdbg/   | <on by default> | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE   | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file |              | $TMPDIR         |                | $SET_TMP      |
+| Java options   |              | $JAVA_OPTS      |                | $JAVA_OPTS    |
 
 The command line executed is effectively (where $@ are the args passed into the 
 docker entry point):

--- a/openjdk8/README.md
+++ b/openjdk8/README.md
@@ -38,13 +38,13 @@ The entry point for the openjdk8 image is [docker-entrypoint.bash](https://githu
 
 If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/appengine-java-vm-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features: ALPN, Cloud Debugger & Cloud Profiler.  Each of these features must be explicitly enabled and not disable by environment variables, and each has a script that is run to determine the required JVM arguments:
 
-| Feature        | directory    | Enable          | Disable        | JVM args      |
-|----------------|--------------|-----------------|----------------|---------------|
-| ALPN           | /opt/alpn/   | $ALPN_ENABLE    | $ALPN_DISABLE  | $ALPN_BOOT    |
-| Cloud Debugger | /opt/cdbg/   | <on by default> | $CDBG_DISABLE  | $DBG_AGENT    |
-| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE   | $CPROF_DISABLE | $PROF_AGENT   |
-| Temporary file |              | $TMPDIR         |                | $SET_TMP      |
-| Java options   |              | $JAVA_OPTS      |                | $JAVA_OPTS    |
+| Feature        | directory    | Enable            | Disable        | JVM args      |
+|----------------|--------------|-------------------|----------------|---------------|
+| ALPN           | /opt/alpn/   | $ALPN_ENABLE      | $ALPN_DISABLE  | $ALPN_BOOT    |
+| Cloud Debugger | /opt/cdbg/   | \<on by default\> | $CDBG_DISABLE  | $DBG_AGENT    |
+| Cloud Profile  | /opt/cprof/  | $CPROF_ENABLE     | $CPROF_DISABLE | $PROF_AGENT   |
+| Temporary file |              | $TMPDIR           |                | $SET_TMP      |
+| Java options   |              | $JAVA_OPTS        |                | $JAVA_OPTS    |
 
 The command line executed is effectively (where $@ are the args passed into the 
 docker entry point):

--- a/openjdk8/src/main/docker/setup-env.bash
+++ b/openjdk8/src/main/docker/setup-env.bash
@@ -4,14 +4,12 @@ if [[ -n "$ALPN_ENABLE" ]]; then
   ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
 fi
 
-DBG_AGENT=
+DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
 if [[ -n "$DBG_ENABLE" ]]; then
   if [[ "$GAE_PARTITION" = "dev" ]]; then
     echo "Running locally and DBG_ENABLE is set, enabling standard Java debugger agent"
     DBG_PORT=${DBG_PORT:-5005}
     DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT}"
-  else
-    DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
   fi
 fi
 


### PR DESCRIPTION
The Cloud Debugger team confirmed that the Debugger issue that forced us to disable it temporarily on the flex env (including Phython runtimes) has been resolved. The team asked me to take an action to enable it. Note that the Debugger is already enabled by default on the standard env (including jetty9-compat), and it should be automatically enabled for Java flex as documented [here](https://cloud.google.com/debugger/docs/setting-up-java-on-app-engine).

I took the liberty to make a change to setup-env.bash at my discretion, but feel free to jump in.

The document [here](https://cloud.google.com/appengine/docs/flexible/java/dev-jetty9?hl=pt-BR#environment_variables) should also be revised to correct the explanation for the DBG_ENALBE env variable.