### PR TITLE
Explicitly unpack root.war (if present) into webapps/root

### DIFF
--- a/gke-debian-openjdk/src/main/docker/Dockerfile
+++ b/gke-debian-openjdk/src/main/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
     openjdk-8-jre \
     netbase \
     wget \ 
-    zip \
+    unzip \
  && apt-get clean \
  && rm /var/lib/apt/lists/*_*
 

--- a/gke-debian-openjdk/src/main/docker/Dockerfile
+++ b/gke-debian-openjdk/src/main/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
     openjdk-8-jre \
     netbase \
     wget \ 
+    zip \
  && apt-get clean \
  && rm /var/lib/apt/lists/*_*
 

--- a/gke-debian-openjdk/src/main/docker/gke-env.bash
+++ b/gke-debian-openjdk/src/main/docker/gke-env.bash
@@ -4,7 +4,7 @@ if [[ -n "$ALPN_ENABLE" ]]; then
   ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
 fi
 
-DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
+DBG_AGENT="$( RUNTIME_DIR=$JETTY_BASE /opt/cdbg/format-env-appengine-vm.sh )"
 if [[ -n "$DBG_ENABLE" ]]; then
   if [[ "$GAE_PARTITION" = "dev" ]]; then
     echo "Running locally and DBG_ENABLE is set, enabling standard Java debugger agent"

--- a/gke-jetty/src/main/docker/Dockerfile
+++ b/gke-jetty/src/main/docker/Dockerfile
@@ -32,11 +32,9 @@ RUN mkdir -p $JETTY_BASE
 WORKDIR $JETTY_BASE
 ADD gke-alpn.mod modules/
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=http,deploy,jsp,jstl,setuid \
- && mkdir -p $JETTY_BASE/webapps/root \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
- && ln -s $JETTY_BASE/webapps/root /app \
- && touch --date '1970/01/01' $JETTY_BASE/webapps/root
+ && ln -s $JETTY_BASE/webapps/root /app
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/gke-jetty/src/main/docker/docker-entrypoint.bash
+++ b/gke-jetty/src/main/docker/docker-entrypoint.bash
@@ -3,9 +3,16 @@
 # default jetty arguments
 DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
-if [ -e "$JETTY_BASE/webapps/root.war" ]; then
-  unzip $JETTY_BASE/webapps/root.war -d $JETTY_BASE/webapps/root
-  chown -R jetty.jetty $JETTY_BASE/webapps/root
+# Unpack a WAR app (if present) beforehand so that Stackdriver Debugger
+# can load it. This should be done before the JVM for Jetty starts up.
+WEBAPP_WAR=$JETTY_BASE/webapps/root.war
+WEBAPP_ROOT=$JETTY_BASE/webapps/root
+if [ -e "$WEBAPP_WAR" ]; then
+  # Unpack it only if $WEBAPP_ROOT doesn't exist or empty.
+  if [ ! -e "$WEBAPP_ROOT" -o ! "$( ls -A $WEBAPP_ROOT )" ]; then
+    unzip $WEBAPP_WAR -d $WEBAPP_ROOT
+    chown -R jetty.jetty $WEBAPP_ROOT
+  fi
 fi
 
 # If the passed arguments start with the java command

--- a/gke-jetty/src/main/docker/docker-entrypoint.bash
+++ b/gke-jetty/src/main/docker/docker-entrypoint.bash
@@ -3,6 +3,11 @@
 # default jetty arguments
 DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
+if [ -e "$JETTY_BASE/webapps/root.war" ]; then
+  unzip $JETTY_BASE/webapps/root.war -d $JETTY_BASE/webapps/root
+  chown -R jetty.jetty $JETTY_BASE/webapps/root
+fi
+
 # If the passed arguments start with the java command
 if [ "java" = "$1" -o "$(which java)" = "$1" ] ; then
   # ignore the java command as it is the default


### PR DESCRIPTION
The previous PR had two problems:

1) Mysteriously, `webapps/root` is still empty (despite its timestamp is changed from 1970/01/01), which only happens in production but not in a local env.
2) Unpacked contents of `root.war` should be present **before** Jetty starts. If Jetty explodes `root.war` while it is being initialized, Stackdriver Debugger can't load the class and lib files of `root.war`.

So, I suggest the following changes that explicitly unpack `root.war`, as an ultimate solution. It works on my local machine and my own ad-hoc testing in production.

What this PR does:

- Revert the last Pull Requst that creates and touches `webapps/root`. (No need to create the directory since `unzip` will create it anyway.)
- Install `unzip`.
- Unpack `root.war` explicitly if present.
- Set `$RUNTIME_DIR` and pass it to `cdbg/format-env-appengine-vm.sh`. (This env variable that the shell script uses was missing.)