### PR TITLE
Explicitly unpack root.war (if present) into webapps/root

### DIFF
--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
  && ln -s $JETTY_BASE/webapps/root /app \
- && touch $JETTY_BASE/webapps/root.xml
+ && touch $JETTY_BASE/webapps/root.war
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -36,11 +36,9 @@ ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
- && mkdir -p $JETTY_BASE/webapps/root \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
- && ln -s $JETTY_BASE/webapps/root /app \
- && touch --date '1970/01/01' $JETTY_BASE/webapps/root
+ && ln -s $JETTY_BASE/webapps/root /app
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -36,9 +36,11 @@ ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
+ && mkdir $JETTY_BASE/webapps/root \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
- && ln -s $JETTY_BASE/webapps/root /app
+ && ln -s $JETTY_BASE/webapps/root /app \
+ && touch $JETTY_BASE/webapps/root.xml
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -36,7 +36,7 @@ ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
 RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
- && mkdir $JETTY_BASE/webapps/root \
+ && mkdir -p $JETTY_BASE/webapps/root \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
  && ln -s $JETTY_BASE/webapps/root /app \

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
  && chown -R jetty:jetty $JETTY_BASE \
  && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
  && ln -s $JETTY_BASE/webapps/root /app \
- && touch $JETTY_BASE/webapps/root.war
+ && touch --date '1970/01/01' $JETTY_BASE/webapps/root
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/docker-entrypoint.bash
+++ b/jetty9/src/main/docker/docker-entrypoint.bash
@@ -3,6 +3,11 @@
 # default jetty arguments
 DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
+if [ -e "$JETTY_BASE/webapps/root.war" ]; then
+  unzip $JETTY_BASE/webapps/root.war -d $JETTY_BASE/webapps/root
+  chown -R jetty.jetty $JETTY_BASE/webapps/root
+fi
+
 # If the passed arguments start with the java command
 if [ "java" = "$1" -o "$(which java)" = "$1" ] ; then
   # ignore the java command as it is the default

--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
     openjdk-8-jre \
     netbase \
     wget \ 
+    unzip \
  && apt-get clean \
  && rm /var/lib/apt/lists/*_*
 

--- a/openjdk8/src/main/docker/setup-env.bash
+++ b/openjdk8/src/main/docker/setup-env.bash
@@ -4,7 +4,7 @@ if [[ -n "$ALPN_ENABLE" ]]; then
   ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
 fi
 
-DBG_AGENT="$( /opt/cdbg/format-env-appengine-vm.sh )"
+DBG_AGENT="$( RUNTIME_DIR=$JETTY_BASE /opt/cdbg/format-env-appengine-vm.sh )"
 if [[ -n "$DBG_ENABLE" ]]; then
   if [[ "$GAE_PARTITION" = "dev" ]]; then
     echo "Running locally and DBG_ENABLE is set, enabling standard Java debugger agent"


### PR DESCRIPTION
Do the same thing in #222 for the `async-support` branch.