### PR TITLE
suppress expected stack traces during unit testing

### DIFF
--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
@@ -42,6 +42,7 @@ import org.apache.http.protocol.HttpContext;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Arrays;
@@ -196,37 +197,30 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
-    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
-    Level level = logger.getLevel();
-    if (!logger.isLoggable(Level.FINE)) {
-      logger.setLevel(Level.SEVERE);
-    }
-    if (sync) {
-      try {
-        environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
-        result =
-            delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
-        fail();
-      } catch (ApiProxyException exception) {
-        assertEquals(expectedException.getClass(), exception.getClass());
-      } finally {
-        logger.setLevel(level);
-      }
-    } else {
-      try {
-        ApiConfig apiConfig = new ApiConfig();
-        apiConfig.setDeadlineInSeconds(timeoutInSeconds);
-        result =
-            delegate
-                .makeAsyncCall(
-                    environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, apiConfig)
-                .get();
-        fail();
-      } catch (ExecutionException exception) {
-        // ExecutionException is expected, and make sure the cause is expected as well.
-        assertEquals(expectedException.getClass(), exception.getCause().getClass());
-      } finally {
-        logger.setLevel(level);
+    try (SuppressedLogging l=new SuppressedLogging()) {
+      if (sync) {
+        try {
+          environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
+          result =
+              delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
+          fail();
+        } catch (ApiProxyException exception) {
+          assertEquals(expectedException.getClass(), exception.getClass());
+        }
+      } else {
+        try {
+          ApiConfig apiConfig = new ApiConfig();
+          apiConfig.setDeadlineInSeconds(timeoutInSeconds);
+          result =
+              delegate
+              .makeAsyncCall(
+                  environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, apiConfig)
+              .get();
+          fail();
+        } catch (ExecutionException exception) {
+          // ExecutionException is expected, and make sure the cause is expected as well.
+          assertEquals(expectedException.getClass(), exception.getCause().getClass());
+        }
       }
     }
     assertNull(result);
@@ -248,38 +242,30 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
-    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
-    Level level = logger.getLevel();
-    if (!logger.isLoggable(Level.FINE)) {
-      logger.setLevel(Level.SEVERE);
-    }
-    
-    if (sync) {
-      try {
-        environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
-        result =
-            delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
-        fail();
-      } catch (ApiProxyException exception) {
-        assertThat(exception, instanceOf(expectedException.getClass()));
-      } finally {
-        logger.setLevel(level);
-      }
-    } else {
-      try {
-        ApiConfig apiConfig = new ApiConfig();
-        apiConfig.setDeadlineInSeconds(timeoutInSeconds);
-        result =
-            delegate
-                .makeAsyncCall(
-                    environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, apiConfig)
-                .get();
-        fail();
-      } catch (ExecutionException exception) {
-        // ExecutionException is expected, and make sure the cause is expected as well.
-        assertThat(exception.getCause(), instanceOf(expectedException.getClass()));
-      } finally {
-        logger.setLevel(level);
+    try (SuppressedLogging l=new SuppressedLogging()) {
+      if (sync) {
+        try {
+          environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
+          result =
+              delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
+          fail();
+        } catch (ApiProxyException exception) {
+          assertThat(exception, instanceOf(expectedException.getClass()));
+        }
+      } else {
+        try {
+          ApiConfig apiConfig = new ApiConfig();
+          apiConfig.setDeadlineInSeconds(timeoutInSeconds);
+          result =
+              delegate
+              .makeAsyncCall(
+                  environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, apiConfig)
+              .get();
+          fail();
+        } catch (ExecutionException exception) {
+          // ExecutionException is expected, and make sure the cause is expected as well.
+          assertThat(exception.getCause(), instanceOf(expectedException.getClass()));
+        }
       }
     }
     assertNull(result);
@@ -299,38 +285,30 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
-    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
-    Level level = logger.getLevel();
-    if (!logger.isLoggable(Level.FINE)) {
-      logger.setLevel(Level.SEVERE);
-    }
-
-    if (sync) {
-      try {
-        environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
-        result =
-            delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
-        fail();
-      } catch (ApiProxyException exception) {
-        assertEquals(expectedException.getClass(), exception.getClass());
-      } finally {
-        logger.setLevel(level);
-      }
-    } else {
-      try {
-        ApiConfig apiConfig = new ApiConfig();
-        apiConfig.setDeadlineInSeconds(timeoutInSeconds);
-        result =
-            delegate
-                .makeAsyncCall(
-                    environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, apiConfig)
-                .get();
-        fail();
-      } catch (ExecutionException exception) {
-        // ExecutionException is expected, and make sure the cause is expected as well.
-        assertEquals(expectedException.getClass(), exception.getCause().getClass());
-      } finally {
-        logger.setLevel(level);
+    try (SuppressedLogging l=new SuppressedLogging()) {
+      if (sync) {
+        try {
+          environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
+          result =
+              delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
+          fail();
+        } catch (ApiProxyException exception) {
+          assertEquals(expectedException.getClass(), exception.getClass());
+        }
+      } else {
+        try {
+          ApiConfig apiConfig = new ApiConfig();
+          apiConfig.setDeadlineInSeconds(timeoutInSeconds);
+          result =
+              delegate
+              .makeAsyncCall(
+                  environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, apiConfig)
+              .get();
+          fail();
+        } catch (ExecutionException exception) {
+          // ExecutionException is expected, and make sure the cause is expected as well.
+          assertEquals(expectedException.getClass(), exception.getCause().getClass());
+        }
       }
     }
     assertNull(result);
@@ -352,35 +330,27 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] requestData = new byte[] {0, 1, 2, 3, 4, 5};
     byte[] result = null;
 
-    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
-    Level level = logger.getLevel();
-    if (!logger.isLoggable(Level.FINE)) {
-      logger.setLevel(Level.SEVERE);
-    }
-    
-    if (sync) {
-      try {
-        result =
-            delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
-        fail();
-      } catch (ApiProxyException exception) {
-        assertEquals(expectedException.getClass(), exception.getClass());
-      } finally {
-        logger.setLevel(level);
-      }
-    } else {
-      try {
-        result =
-            delegate
-                .makeAsyncCall(
-                    environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, new ApiConfig())
-                .get();
-        fail();
-      } catch (ExecutionException exception) {
-        // ExecutionException is expected, and make sure the cause is expected as well.
-        assertEquals(expectedException.getClass(), exception.getCause().getClass());
-      } finally {
-        logger.setLevel(level);
+    try (SuppressedLogging l=new SuppressedLogging()) {
+      if (sync) {
+        try {
+          result =
+              delegate.makeSyncCall(environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData);
+          fail();
+        } catch (ApiProxyException exception) {
+          assertEquals(expectedException.getClass(), exception.getClass());
+        }
+      } else {
+        try {
+          result =
+              delegate
+              .makeAsyncCall(
+                  environment, TEST_PACKAGE_NAME, TEST_METHOD_NAME, requestData, new ApiConfig())
+              .get();
+          fail();
+        } catch (ExecutionException exception) {
+          // ExecutionException is expected, and make sure the cause is expected as well.
+          assertEquals(expectedException.getClass(), exception.getCause().getClass());
+        }
       }
     }
     assertNull(result);
@@ -565,5 +535,21 @@ public class VmApiProxyDelegateTest extends TestCase {
     assertEquals(
         "The remote RPC to the application server failed for the call barf.d().",
         exception.getMessage());
+  }
+  
+  private static class SuppressedLogging implements Closeable {
+    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
+    Level level = logger.getLevel();
+    
+    SuppressedLogging() {
+      if (!logger.isLoggable(Level.FINE)) {
+        logger.setLevel(Level.SEVERE);
+      }
+    }
+    
+    @Override
+    public void close() throws IOException {
+      logger.setLevel(level);
+    }
   }
 }

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
@@ -197,7 +197,7 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
-    try (SuppressedLogging l=new SuppressedLogging()) {
+    try (SuppressedLogging l = new SuppressedLogging()) {
       if (sync) {
         try {
           environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
@@ -242,7 +242,7 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
-    try (SuppressedLogging l=new SuppressedLogging()) {
+    try (SuppressedLogging l = new SuppressedLogging()) {
       if (sync) {
         try {
           environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
@@ -285,7 +285,7 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
-    try (SuppressedLogging l=new SuppressedLogging()) {
+    try (SuppressedLogging l = new SuppressedLogging()) {
       if (sync) {
         try {
           environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
@@ -330,7 +330,7 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] requestData = new byte[] {0, 1, 2, 3, 4, 5};
     byte[] result = null;
 
-    try (SuppressedLogging l=new SuppressedLogging()) {
+    try (SuppressedLogging l = new SuppressedLogging()) {
       if (sync) {
         try {
           result =
@@ -542,6 +542,10 @@ public class VmApiProxyDelegateTest extends TestCase {
     Level level = logger.getLevel();
     
     SuppressedLogging() {
+      // If the logger is not configured to log debug level
+      // logs (FINE, FINER, FINEST), then set the logger
+      // to SEVERE, so that the expected WARNING messages
+      // from these tests are suppressed.
       if (!logger.isLoggable(Level.FINE)) {
         logger.setLevel(Level.SEVERE);
       }

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
@@ -48,6 +48,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Tests the delegate for making AppEngine API calls in a Google Compute Engine VM.
@@ -194,6 +196,11 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
+    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
+    Level level = logger.getLevel();
+    if (!logger.isLoggable(Level.FINE)) {
+      logger.setLevel(Level.SEVERE);
+    }
     if (sync) {
       try {
         environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
@@ -202,6 +209,8 @@ public class VmApiProxyDelegateTest extends TestCase {
         fail();
       } catch (ApiProxyException exception) {
         assertEquals(expectedException.getClass(), exception.getClass());
+      } finally {
+        logger.setLevel(level);
       }
     } else {
       try {
@@ -216,6 +225,8 @@ public class VmApiProxyDelegateTest extends TestCase {
       } catch (ExecutionException exception) {
         // ExecutionException is expected, and make sure the cause is expected as well.
         assertEquals(expectedException.getClass(), exception.getCause().getClass());
+      } finally {
+        logger.setLevel(level);
       }
     }
     assertNull(result);
@@ -237,6 +248,12 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
+    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
+    Level level = logger.getLevel();
+    if (!logger.isLoggable(Level.FINE)) {
+      logger.setLevel(Level.SEVERE);
+    }
+    
     if (sync) {
       try {
         environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
@@ -245,6 +262,8 @@ public class VmApiProxyDelegateTest extends TestCase {
         fail();
       } catch (ApiProxyException exception) {
         assertThat(exception, instanceOf(expectedException.getClass()));
+      } finally {
+        logger.setLevel(level);
       }
     } else {
       try {
@@ -259,6 +278,8 @@ public class VmApiProxyDelegateTest extends TestCase {
       } catch (ExecutionException exception) {
         // ExecutionException is expected, and make sure the cause is expected as well.
         assertThat(exception.getCause(), instanceOf(expectedException.getClass()));
+      } finally {
+        logger.setLevel(level);
       }
     }
     assertNull(result);
@@ -278,6 +299,12 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] result = null;
     final Double timeoutInSeconds = 10.0;
 
+    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
+    Level level = logger.getLevel();
+    if (!logger.isLoggable(Level.FINE)) {
+      logger.setLevel(Level.SEVERE);
+    }
+
     if (sync) {
       try {
         environment.getAttributes().put(VmApiProxyDelegate.API_DEADLINE_KEY, timeoutInSeconds);
@@ -286,6 +313,8 @@ public class VmApiProxyDelegateTest extends TestCase {
         fail();
       } catch (ApiProxyException exception) {
         assertEquals(expectedException.getClass(), exception.getClass());
+      } finally {
+        logger.setLevel(level);
       }
     } else {
       try {
@@ -300,6 +329,8 @@ public class VmApiProxyDelegateTest extends TestCase {
       } catch (ExecutionException exception) {
         // ExecutionException is expected, and make sure the cause is expected as well.
         assertEquals(expectedException.getClass(), exception.getCause().getClass());
+      } finally {
+        logger.setLevel(level);
       }
     }
     assertNull(result);
@@ -321,6 +352,12 @@ public class VmApiProxyDelegateTest extends TestCase {
     byte[] requestData = new byte[] {0, 1, 2, 3, 4, 5};
     byte[] result = null;
 
+    Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
+    Level level = logger.getLevel();
+    if (!logger.isLoggable(Level.FINE)) {
+      logger.setLevel(Level.SEVERE);
+    }
+    
     if (sync) {
       try {
         result =
@@ -328,6 +365,8 @@ public class VmApiProxyDelegateTest extends TestCase {
         fail();
       } catch (ApiProxyException exception) {
         assertEquals(expectedException.getClass(), exception.getClass());
+      } finally {
+        logger.setLevel(level);
       }
     } else {
       try {
@@ -340,6 +379,8 @@ public class VmApiProxyDelegateTest extends TestCase {
       } catch (ExecutionException exception) {
         // ExecutionException is expected, and make sure the cause is expected as well.
         assertEquals(expectedException.getClass(), exception.getCause().getClass());
+      } finally {
+        logger.setLevel(level);
       }
     }
     assertNull(result);


### PR DESCRIPTION
Configure the logger during the unit tests so that unless debug has been requested, the expected stack traces are suppressed.