### PR TITLE
Disable Stackdriver Debugger when running locally

### DIFF
--- a/openjdk8/src/main/docker/setup-env.bash
+++ b/openjdk8/src/main/docker/setup-env.bash
@@ -4,13 +4,14 @@ if [[ -n "$ALPN_ENABLE" ]]; then
   ALPN_BOOT="$( /opt/alpn/format-env-appengine-vm.sh )"
 fi
 
-DBG_AGENT="$( RUNTIME_DIR=$JETTY_BASE /opt/cdbg/format-env-appengine-vm.sh )"
-if [[ -n "$DBG_ENABLE" ]]; then
-  if [[ "$GAE_PARTITION" = "dev" ]]; then
+if [[ "$GAE_PARTITION" = "dev" ]]; then
+  if [[ -n "$DBG_ENABLE" ]]; then
     echo "Running locally and DBG_ENABLE is set, enabling standard Java debugger agent"
     DBG_PORT=${DBG_PORT:-5005}
     DBG_AGENT="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DBG_PORT}"
   fi
+else
+  DBG_AGENT="$( RUNTIME_DIR=$JETTY_BASE /opt/cdbg/format-env-appengine-vm.sh )"
 fi
 
 PROF_AGENT=


### PR DESCRIPTION
Internal bug: 28192592

Do not enable Stackdriver Debugger for local runs.

Please sync this with the master branch too.