### PR TITLE
Issue #259 Hide GAE API from webapp classpath

### DIFF
--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/VmRuntimeFileLogHandler.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/VmRuntimeFileLogHandler.java
@@ -19,6 +19,7 @@ package com.google.apphosting.vmruntime;
 import com.google.apphosting.logging.JsonFormatter;
 
 import java.io.IOException;
+import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/vmruntime/VmApiProxyDelegateTest.java
@@ -542,6 +542,7 @@ public class VmApiProxyDelegateTest extends TestCase {
         exception.getMessage());
   }
 
+  // TODO move to a common testing framework
   private static class SuppressedLogging implements Closeable {
     Logger logger = Logger.getLogger(VmApiProxyDelegate.class.getName());
     Level level = logger.getLevel();

--- a/jetty9-compat-base/pom.xml
+++ b/jetty9-compat-base/pom.xml
@@ -78,6 +78,13 @@
       <type>jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jstl</artifactId>
+      <version>${jetty.version}</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/jetty9-compat-base/pom.xml
+++ b/jetty9-compat-base/pom.xml
@@ -28,6 +28,10 @@
   <artifactId>jetty9-compat-base</artifactId>
   <packaging>jar</packaging>
 
+  <properties>
+    <appengine.api.provided.version>${appengine.api.version}</appengine.api.provided.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>
@@ -162,8 +166,8 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy-test-webapp-war</id>
-            <phase>pre-integration-test</phase>
+            <id>copy-wars-and-jars</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>copy</goal>
             </goals>
@@ -179,12 +183,21 @@
                   <outputDirectory>${project.build.directory}/webapps/</outputDirectory>
                   <destFileName>testwebapp.war</destFileName>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>com.google.appengine</groupId>
+                  <artifactId>appengine-api-1.0-sdk</artifactId>
+                  <version>${appengine.api.provided.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**</includes>
+                  <outputDirectory>${project.build.directory}/jetty-base/lib/gae/provided-api/</outputDirectory>
+                </artifactItem>
               </artifactItems>
             </configuration>
           </execution>
           <execution>
             <id>unpack-deps</id>
-            <phase>pre-integration-test</phase>
+            <phase>generate-resources</phase>
             <goals>
               <goal>unpack</goal>
             </goals>
@@ -213,7 +226,7 @@
           </execution>
           <execution>
             <id>gae-jars</id>
-            <phase>pre-integration-test</phase>
+            <phase>generate-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -24,6 +24,9 @@ import java.util.logging.Level;
 
 public class AppengineApiConfiguration extends AbstractConfiguration {
 
+  // A class to check if the GAE API is available.
+  public final static String GAE_CHECK_CLASS = "com.google.appengine.api.ThreadManager";
+  
   // Hide the all container classes from the webapplication
   // TODO update to use '.' when supported by Jetty
   private static final String[] SERVER_CLASSES = {
@@ -34,6 +37,7 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
   };
 
   private static final String[] SHARED_CLASSES = {
+    // Expose the GAE API classes
     "com.google.appengine.api.LifecycleManager",
     "com.google.apphosting.api.ApiProxy",
     "com.google.apphosting.api.ApiStats",
@@ -64,9 +68,9 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
       context.addServerClass(systemClass);
     }
     for (String gaeClass : SHARED_CLASSES) {
-      // Don't hide GAE v1 shared classes
+      // Don't hide shared classes
       context.prependServerClass("-" + gaeClass);
-      // Don't GAE v1 shared classes to be replaced by webapp
+      // Don't allow shared classes to be replaced by webapp
       context.addSystemClass(gaeClass);
     }
   }
@@ -75,11 +79,11 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     ClassLoader loader = context.getClassLoader();
     try {
       // Test if the appengine api is available
-      loader.loadClass("com.google.appengine.api.ThreadManager");
+      loader.loadClass(GAE_CHECK_CLASS);
     } catch (Exception ex) {
       VmRuntimeWebAppContext.logger.log(Level.FINE, "No appengined API", ex);
       VmRuntimeWebAppContext.logger.log(
-          Level.WARNING, "No appengined API including in WEB-INF/lib! Please update your SDK!");
+          Level.WARNING, "No appengined API jar including in WEB-INF/lib! Please update your SDK!");
 
       // The appengine API is not available so we will add it and it's dependencies
       Resource providedApi =
@@ -98,7 +102,7 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
       }
 
       // Ensure the API can now be loaded
-      loader.loadClass("com.google.appengine.api.ThreadManager");
+      loader.loadClass(GAE_CHECK_CLASS);
     }
   }
 }

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.apphosting.vmruntime.jetty9;
+
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.webapp.AbstractConfiguration;
+import org.eclipse.jetty.webapp.WebAppClassLoader;
+import org.eclipse.jetty.webapp.WebAppContext;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+
+public class AppengineApiConfiguration extends AbstractConfiguration {
+
+  // Hide the server implementation classes from the webapplication
+  // TODO Regularly review this list; or automate generation; or change to whitelist
+  private static final String[] SERVER_CLASSES = {
+    "com.google.",
+    "javax.cache.",
+    "org.apache.commons.",
+    "org.apache.geronimo.",
+    "org.apache.http.",
+    "mozilla."
+  };
+
+  private static final String[] GAE_STANDARD_V1_SHAREED_CLASSES = {
+    "com.google.appengine.api.LifecycleManager",
+    "com.google.apphosting.api.ApiProxy",
+    "com.google.apphosting.api.ApiStats",
+    "com.google.apphosting.api.CloudTrace",
+    "com.google.apphosting.api.CloudTraceContext",
+    "com.google.apphosting.api.DeadlineExceededException",
+    "com.google.apphosting.runtime.SessionData",
+    "com.google.apphosting.runtime.UncatchableError",
+    
+    // TODO review if these should be shared or provided?
+    "javax.activation.",
+    "javax.mail.",
+  };
+
+  @Override
+  public void preConfigure(WebAppContext context) throws Exception {
+    for (String systemClass : SERVER_CLASSES) {
+      context.addServerClass(systemClass);
+    }
+    for (String gaeClass : GAE_STANDARD_V1_SHAREED_CLASSES) {
+      // Don't hide GAE v1 shared classes
+      context.prependServerClass("-" + gaeClass);
+      // Don't GAE v1 shared classes to be replaced by webapp
+      context.addSystemClass(gaeClass);
+    }
+  }
+
+  public void configure(WebAppContext context) throws Exception {
+    ClassLoader loader = context.getClassLoader();
+    try {
+      // Test if the appengine api is available
+      loader.loadClass("com.google.appengine.api.ThreadManager");
+    } catch (Exception ex) {
+      VmRuntimeWebAppContext.logger.log(Level.FINE, "No appengined API", ex);
+      VmRuntimeWebAppContext.logger.log(
+          Level.WARNING, "No appengined API including in WEB-INF/lib! Please update your SDK!");
+
+      // The appengine API is not available so we will add it and it's dependencies
+      Resource providedApi =
+          Resource.newResource(
+              URIUtil.addPaths(System.getProperty("jetty.base"), "/lib/gae/provided-api/"));
+
+      if (providedApi != null) {
+        String[] list = providedApi.list();
+        if (list != null) {
+          WebAppClassLoader wloader = (WebAppClassLoader) loader;
+          for (String jar : list) {
+            wloader.addClassPath(providedApi.addPath(jar));
+            VmRuntimeWebAppContext.logger.log(Level.INFO, "Added " + jar + " to webapp classpath");
+          }
+        }
+      }
+
+      // Ensure the API can now be loaded
+      loader.loadClass("com.google.appengine.api.ThreadManager");
+    }
+  }
+}

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -38,6 +38,10 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     "mozilla."
   };
 
+  // Classes & Packages to be shared from the containers classloader
+  // to the webapp.  Classes included here will be marked both as 
+  // exclusions from serverclasses (not hidden from webapp) and inclusion
+  // to the systemclasses (cannot be overriden by the webapp)
   private static final String[] SHARED_CLASSES = {
     // Expose the GAE API classes
     "com.google.appengine.api.LifecycleManager",

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -25,14 +25,14 @@ import java.util.logging.Level;
 public class AppengineApiConfiguration extends AbstractConfiguration {
 
   // A class to check if the GAE API is available.
-  public final static String GAE_CHECK_CLASS = "com.google.appengine.api.ThreadManager";
-  
+  public static final String GAE_CHECK_CLASS = "com.google.appengine.api.ThreadManager";
+
   // Hide the all container classes from the webapplication
   // TODO update to use '.' when supported by Jetty
   private static final String[] SERVER_CLASSES = {
-    "com.",
-    "javax.",
-    "org.",
+    "com.", 
+    "javax.", 
+    "org.", 
     "mozilla."
   };
 
@@ -46,20 +46,20 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     "com.google.apphosting.api.DeadlineExceededException",
     "com.google.apphosting.runtime.SessionData",
     "com.google.apphosting.runtime.UncatchableError",
-    
+
     // Expose the standard APIs that are provided
     "javax.servlet.",
     "javax.el.",
     "javax.annotation.",
     "javax.activation.", // TODO Review
     "javax.mail.", // TODO Review
-    
+
     // Expose classes needed for JSP and JSTL
     "org.apache.jasper.runtime.",
     "org.apache.jasper.JasperException",
     "org.apache.el.ExpressionFactoryImpl",
     "org.apache.tomcat.InstanceManager",
-    "org.apache.taglibs.",    
+    "org.apache.taglibs.",
   };
 
   @Override

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -1,15 +1,17 @@
 /*
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.google.apphosting.vmruntime.jetty9;
@@ -112,8 +114,13 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
       loader.loadClass(GAE_CHECK_CLASS);
     } catch (Exception ex) {
       VmRuntimeWebAppContext.logger.log(Level.FINE, "No appengined API", ex);
-      VmRuntimeWebAppContext.logger.log(
-          Level.WARNING, "No appengined API jar including in WEB-INF/lib! Please update your SDK!");
+      if (VmRuntimeWebAppContext.logger.isLoggable(Level.FINE)) {
+        VmRuntimeWebAppContext.logger.log(Level.WARNING,
+            "No appengine API jar included in WEB-INF/lib! Please update your SDK!", ex);
+      } else {
+        VmRuntimeWebAppContext.logger.log(Level.WARNING,
+            "No appengine API jar included in WEB-INF/lib! Please update your SDK!");
+      }
 
       // The appengine API is not available so we will add it and it's dependencies
       Resource providedApi =

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -47,13 +47,42 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     "com.google.apphosting.runtime.SessionData",
     "com.google.apphosting.runtime.UncatchableError",
 
-    // Expose the standard APIs that are provided
+    // Expose the standard APIs that are provided by the container
     "javax.servlet.",
     "javax.el.",
-    "javax.annotation.",
-    "javax.activation.", // TODO Review
     "javax.mail.", // TODO Review
-    "javax.imageio.", // TODO Review: Required by guestbook example
+    
+    // Expose the standard APIs that are provided by the JVM
+    "com.oracle.",
+    "com.sun.",
+    "javax.accessibility.",
+    "javax.activation.",
+    "javax.activity.",
+    "javax.annotation.",
+    "javax.imageio.",
+    "javax.jws.",
+    "javax.lang.model.",
+    "javax.management.",
+    "javax.naming.",
+    "javax.net.",
+    "javax.print.",
+    "javax.rmi.",
+    "javax.script.",
+    "javax.security.",
+    "javax.smartcardio.",
+    "javax.sound.",
+    "javax.sql.",
+    "javax.swing.",
+    "javax.tools.",
+    "javax.transaction.",
+    "javax.xml.",
+    "jdk.",
+    "org.ietf.jgss.",
+    "org.jcp.xml.dsig.internal.",
+    "org.omg.",
+    "org.w3c.dom.",
+    "org.xml.",
+    "sun.",
 
     // Expose classes needed for JSP and JSTL
     "org.apache.jasper.runtime.",

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -117,7 +117,6 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
       // Test if the appengine api is available
       loader.loadClass(GAE_CHECK_CLASS);
     } catch (Exception ex) {
-      VmRuntimeWebAppContext.logger.log(Level.FINE, "No appengined API", ex);
       if (VmRuntimeWebAppContext.logger.isLoggable(Level.FINE)) {
         VmRuntimeWebAppContext.logger.log(Level.WARNING,
             "No appengine API jar included in WEB-INF/lib! Please update your SDK!", ex);

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -24,18 +24,16 @@ import java.util.logging.Level;
 
 public class AppengineApiConfiguration extends AbstractConfiguration {
 
-  // Hide the server implementation classes from the webapplication
-  // TODO Regularly review this list; or automate generation; or change to whitelist
+  // Hide the all container classes from the webapplication
+  // TODO update to use '.' when supported by Jetty
   private static final String[] SERVER_CLASSES = {
-    "com.google.",
-    "javax.cache.",
-    "org.apache.commons.",
-    "org.apache.geronimo.",
-    "org.apache.http.",
+    "com.",
+    "javax.",
+    "org.",
     "mozilla."
   };
 
-  private static final String[] GAE_STANDARD_V1_SHAREED_CLASSES = {
+  private static final String[] SHARED_CLASSES = {
     "com.google.appengine.api.LifecycleManager",
     "com.google.apphosting.api.ApiProxy",
     "com.google.apphosting.api.ApiStats",
@@ -45,9 +43,19 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     "com.google.apphosting.runtime.SessionData",
     "com.google.apphosting.runtime.UncatchableError",
     
-    // TODO review if these should be shared or provided?
-    "javax.activation.",
-    "javax.mail.",
+    // Expose the standard APIs that are provided
+    "javax.servlet.",
+    "javax.el.",
+    "javax.annotation.",
+    "javax.activation.", // TODO Review
+    "javax.mail.", // TODO Review
+    
+    // Expose classes needed for JSP and JSTL
+    "org.apache.jasper.runtime.",
+    "org.apache.jasper.JasperException",
+    "org.apache.el.ExpressionFactoryImpl",
+    "org.apache.tomcat.InstanceManager",
+    "org.apache.taglibs.",    
   };
 
   @Override
@@ -55,7 +63,7 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     for (String systemClass : SERVER_CLASSES) {
       context.addServerClass(systemClass);
     }
-    for (String gaeClass : GAE_STANDARD_V1_SHAREED_CLASSES) {
+    for (String gaeClass : SHARED_CLASSES) {
       // Don't hide GAE v1 shared classes
       context.prependServerClass("-" + gaeClass);
       // Don't GAE v1 shared classes to be replaced by webapp

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -20,7 +20,6 @@ import org.eclipse.jetty.webapp.AbstractConfiguration;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
 
-import java.util.Arrays;
 import java.util.logging.Level;
 
 public class AppengineApiConfiguration extends AbstractConfiguration {
@@ -52,7 +51,7 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
   };
 
   @Override
-  public void preConfigure(WebAppContext context) throws Exception {
+  public void preConfigure(WebAppContext context) {
     for (String systemClass : SERVER_CLASSES) {
       context.addServerClass(systemClass);
     }

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/AppengineApiConfiguration.java
@@ -53,6 +53,7 @@ public class AppengineApiConfiguration extends AbstractConfiguration {
     "javax.annotation.",
     "javax.activation.", // TODO Review
     "javax.mail.", // TODO Review
+    "javax.imageio.", // TODO Review: Required by guestbook example
 
     // Expose classes needed for JSP and JSTL
     "org.apache.jasper.runtime.",

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
@@ -521,24 +521,20 @@ public class VmRuntimeWebAppContext extends WebAppContext
                 transactionRollback.invoke(tx);
               } catch (InvocationTargetException ex) {
                 logger.log(
-                    Level.WARNING,
-                    "Swallowing an target exception we received while trying to rollback "
-                        + "abandoned transaction "
-                        + id,
+                    Level.WARNING, 
+                    "Failed to rollback abandoned transaction " + id,
                     ex.getTargetException());
               } catch (Exception ex) {
                 logger.log(
                     Level.WARNING,
-                    "Swallowing an exception we received while trying to rollback "
-                        + "abandoned transaction "
-                        + id,
+                    "Failed to rollback abandoned transaction " + id,
                     ex);
               }
             }
           }
         } catch (Exception ex) {
           logger.log(
-              Level.WARNING, "Swallowing an exception we received while trying to rollback ", ex);
+              Level.WARNING, "Failed to rollback abandoned transaction", ex);
         }
       }
     }

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
@@ -16,7 +16,6 @@
 
 package com.google.apphosting.vmruntime.jetty9;
 
-import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Transaction;
 import com.google.appengine.api.memcache.MemcacheSerialization;
@@ -44,7 +43,6 @@ import com.google.apphosting.vmruntime.VmRuntimeFileLogHandler;
 import com.google.apphosting.vmruntime.VmRuntimeUtils;
 import com.google.apphosting.vmruntime.VmTimer;
 
-import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.quickstart.PreconfigureDescriptorProcessor;
 import org.eclipse.jetty.quickstart.QuickStartDescriptorGenerator;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -188,8 +186,6 @@ public class VmRuntimeWebAppContext extends WebAppContext
           .addDescriptorProcessor(preconfigProcessor = new PreconfigureDescriptorProcessor());
     }
 
-    // DatastoreServiceFactory.getDatastoreService();
-
     super.doStart();
 
     // Look for a datastore service within the context
@@ -280,12 +276,6 @@ public class VmRuntimeWebAppContext extends WebAppContext
     metadataCache = new VmMetadataCache();
     wallclockTimer = new VmTimer();
     ApiProxy.setDelegate(new VmApiProxyDelegate());
-  }
-
-  @Override
-  public void configure() throws Exception {
-    // TODO Auto-generated method stub
-    super.configure();
   }
 
   /**

--- a/jetty9-compat-base/src/main/jetty-base/webapps/root.xml
+++ b/jetty9-compat-base/src/main/jetty-base/webapps/root.xml
@@ -28,14 +28,8 @@
     <Arg><SystemProperty name="appengine_web_xml" default="WEB-INF/appengine-web.xml"/></Arg>
   </Call>
 
-  <!-- Set quickstartWebXml finle to generate rather than start -->
+  <!-- Set quickstartWebXml to generate rather than start -->
   <Set name="quickstartWebXml"><SystemProperty name="quickstart_web_xml"/></Set>
-
-  <!-- Hide the additional server implementation libraries -->
-  <Call name="addServerClass"><Arg>org.apache.commons.codec.</Arg></Call>
-  <Call name="addServerClass"><Arg>org.apache.commons.logging.</Arg></Call>
-  <Call name="addServerClass"><Arg>org.apache.http.</Arg></Call>
-  <Call name="addServerClass"><Arg>com.google.gson.</Arg></Call>
 
   <Set name="parentLoaderPriority">
     <SystemProperty name="jetty_parent_classloader" default="false"/>

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/JettyRunner.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/JettyRunner.java
@@ -194,6 +194,8 @@ class JettyRunner extends AbstractLifeCycle implements Runnable {
               .collect(Collectors.toList()));
 
       // Needed to initialize JSP!
+      context.setAttribute("org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern", 
+          ".*/[^/]*taglibs.*\\.jar$");
       context.addBean(
           new AbstractLifeCycle() {
             @Override

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/JettyRunner.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/JettyRunner.java
@@ -187,7 +187,7 @@ class JettyRunner extends AbstractLifeCycle implements Runnable {
       final VmRuntimeWebAppContext context = new VmRuntimeWebAppContext();
       context.setContextPath("/");
 
-      // remove annotations
+      // remove annotations as they are too slow for testing
       context.setConfigurationClasses(
           Arrays.stream(context.getConfigurationClasses())
               .filter(n -> !n.contains("AnnotationConfiguration"))

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
@@ -70,8 +70,8 @@ public class VmRuntimeJettyKitchenSinkIT extends VmRuntimeTestBase {
     int count = 0;
     for (String line : lines) {
       line = line.trim();
-      if (line.length() > 0 && Character.isDigit(line.charAt(0))) {
-        int value = Integer.valueOf(line);
+      if (!line.isEmpty() && Character.isDigit(line.charAt(0))) {
+        int value = Integer.parseInt(line);
         count++;
         if (value > max) {
           max = value;

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
@@ -67,11 +67,11 @@ public class VmRuntimeJettyKitchenSinkIT extends VmRuntimeTestBase {
    */
   public void testJstlJSP() throws Exception {
     String[] lines = fetchUrl(createUrl("/jstl.jsp"));
-    int max=-1;
-    int count=0;
+    int max = -1;
+    int count = 0;
     for (String line : lines) {
       line = line.trim();
-      if (line.length()>0 && Character.isDigit(line.charAt(0))) {
+      if (line.length() > 0 && Character.isDigit(line.charAt(0))) {
         int value = Integer.valueOf(line);
         count++;
         if (value > max) {

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
@@ -63,6 +63,27 @@ public class VmRuntimeJettyKitchenSinkIT extends VmRuntimeTestBase {
   }
 
   /**
+   * Test that non compiled jstl JSP  can be served.
+   */
+  public void testJstlJSP() throws Exception {
+    String[] lines = fetchUrl(createUrl("/jstl.jsp"));
+    int max=-1;
+    int count=0;
+    for (String line : lines) {
+      line = line.trim();
+      if (line.length()>0 && Character.isDigit(line.charAt(0))) {
+        int value = Integer.valueOf(line);
+        count++;
+        if (value > max) {
+          max = value;
+        }
+      }
+    }
+    assertEquals(10, count);
+    assertEquals(10, max);
+  }
+
+  /**
    * Tests that mapping a servlet to / works.
    */
   public void testWelcomeServlet() throws Exception {

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
@@ -53,7 +53,6 @@ public class VmRuntimeJettyKitchenSinkIT extends VmRuntimeTestBase {
         fetchUrl(createUrl(String.format("/hello_not_compiled.jsp?start=%d&end=%d", iter, end)));
     String iterationFormat = "<h2>Iteration %d</h2>";
     for (String line : lines) {
-      System.out.println(line);
       if (!line.contains("Iteration")) {
         continue;
       }

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,13 @@
             </execution>
           </executions>
         </plugin>
-
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.10</version>
+        </plugin>
+        
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.18</version>
+	  <configuration>
+	    <useSystemClassLoader>false</useSystemClassLoader>
+	  </configuration>
         </plugin>
 
        <plugin>
@@ -249,6 +252,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.19.1</version>
+	<configuration>
+	  <useSystemClassLoader>false</useSystemClassLoader>
+	</configuration>
         <executions>
           <execution>
             <goals>

--- a/testwebapp/src/main/webapp/jstl.jsp
+++ b/testwebapp/src/main/webapp/jstl.jsp
@@ -1,0 +1,15 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %> 
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>JSTL Example</h1>
+    <hr>
+    <p>A trivial jstl example
+    <hr>
+    <c:forEach var="i" begin="1" end="10" step="1">
+      <c:out value="${i}" />
+      <br />
+    </c:forEach>
+  </body>
+</html>


### PR DESCRIPTION
Handles #259 bu creating AppengineApiConfiguration to manage the classpath that is exposed and/or protected from the webapplication.    If the GAE API is not available in the webapp, then a warning is logged and the API is added to the classpath.

Currently javax.activation and javax.mail are treated as shared classes and the containers version is made available. If these are not listed, then even if they are in the added API jar, errors occur, which needs to be investigated.

Currently a specific list of org.apache packages are hidden.   A better approach may be to hide all org.apache classes and selectively reveals those needed for JSP, JSTL and EL support?