### PR TITLE
Ignore comments between XML tags and add XML parsing tests.

### DIFF
--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessor.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessor.java
@@ -591,7 +591,7 @@ class AppEngineWebXmlProcessor {
     appEngineWebXml.setApiConfig(new ApiConfig(servlet, url));
 
     for (Element subNode : getNodeIterable(node, "endpoint-servlet-mapping-id")) {
-      String id = trim(XmlUtils.getText(subNode));
+      String id = XmlUtils.getText(subNode);
       if (id != null && id.length() > 0) {
         appEngineWebXml.addApiEndpoint(id);
       }

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessor.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessor.java
@@ -231,48 +231,48 @@ class AppEngineWebXmlProcessor {
   }
 
   private void processApplicationNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setAppId(getTextNode(node));
+    appEngineWebXml.setAppId(XmlUtils.getText(node));
   }
 
   private void processPublicRootNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setPublicRoot(getTextNode(node));
+    appEngineWebXml.setPublicRoot(XmlUtils.getText(node));
   }
 
   private void processVersionNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setMajorVersionId(getTextNode(node));
+    appEngineWebXml.setMajorVersionId(XmlUtils.getText(node));
   }
 
   private void processSourceLanguageNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setSourceLanguage(getTextNode(node));
+    appEngineWebXml.setSourceLanguage(XmlUtils.getText(node));
   }
 
   private void processModuleNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setModule(getTextNode(node));
+    appEngineWebXml.setModule(XmlUtils.getText(node));
   }
 
   private void processServiceNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setService(getTextNode(node));
+    appEngineWebXml.setService(XmlUtils.getText(node));
   }
 
   private void processInstanceClassNode(Element node, AppEngineWebXml appEngineWebXml) {
 
-    appEngineWebXml.setInstanceClass(getTextNode(node));
+    appEngineWebXml.setInstanceClass(XmlUtils.getText(node));
   }
 
   private String getChildNodeText(Element parentNode, String childTag) {
-    String result = null;
     Element node = XmlUtils.getOptionalChildElement(parentNode, childTag);
-    if (node != null) {
-      result = XmlUtils.getBody(node);
+    if (node == null) {
+      return null;
     }
-    return result;
+    String result = XmlUtils.getText(node);
+    return result.isEmpty() ? null : result;
   }
 
   private Integer getChildNodePositiveInteger(Element parentNode, String childTag) {
     Integer result = null;
     Element node = XmlUtils.getOptionalChildElement(parentNode, childTag);
-    if (node != null && XmlUtils.getBody(node) != null) {
-      String trimmedText = (XmlUtils.getBody(node)).trim();
+    if (node != null) {
+      String trimmedText = XmlUtils.getText(node);
       if (!trimmedText.isEmpty()) {
         try {
           result = Integer.parseInt(trimmedText);
@@ -291,8 +291,8 @@ class AppEngineWebXmlProcessor {
   private Double getChildNodeDouble(Element parentNode, String childTag) {
     Double result = null;
     Element node = XmlUtils.getOptionalChildElement(parentNode, childTag);
-    if (node != null && XmlUtils.getBody(node) != null) {
-      String trimmedText = (XmlUtils.getBody(node)).trim();
+    if (node != null) {
+      String trimmedText = XmlUtils.getText(node);
       if (!trimmedText.isEmpty()) {
         try {
           result = Double.parseDouble(trimmedText);
@@ -407,7 +407,7 @@ class AppEngineWebXmlProcessor {
   }
 
   private void processAutoIdPolicyNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setAutoIdPolicy(getTextNode(node));
+    appEngineWebXml.setAutoIdPolicy(XmlUtils.getText(node));
   }
 
   private void processCodeLockNode(Element node, AppEngineWebXml appEngineWebXml) {
@@ -419,7 +419,7 @@ class AppEngineWebXmlProcessor {
   }
 
   private void processEnvNode(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setEnv(getTextNode(node));
+    appEngineWebXml.setEnv(XmlUtils.getText(node));
   }
 
   private void processFilesetNode(Element node, AppEngineWebXml appEngineWebXml, FileType type) {
@@ -521,7 +521,7 @@ class AppEngineWebXmlProcessor {
       network.setInstanceTag(instanceTag);
     }
     for (Element subNode : getNodeIterable(settingsNode, "forwarded-port")) {
-      String forwardedPort = getTextNode(subNode);
+      String forwardedPort = XmlUtils.getText(subNode);
       network.addForwardedPort(forwardedPort);
     }
     String name = trim(getChildNodeText(settingsNode, "name"));
@@ -558,7 +558,7 @@ class AppEngineWebXmlProcessor {
 
   private void processInboundServicesNode(Element node, AppEngineWebXml appEngineWebXml) {
     for (Element subNode : getNodeIterable(node, "service")) {
-      String service = getTextNode(subNode);
+      String service = XmlUtils.getText(subNode);
       appEngineWebXml.addInboundService(service);
     }
   }
@@ -591,7 +591,7 @@ class AppEngineWebXmlProcessor {
     appEngineWebXml.setApiConfig(new ApiConfig(servlet, url));
 
     for (Element subNode : getNodeIterable(node, "endpoint-servlet-mapping-id")) {
-      String id = trim(getTextNode(subNode));
+      String id = trim(XmlUtils.getText(subNode));
       if (id != null && id.length() > 0) {
         appEngineWebXml.addApiEndpoint(id);
       }
@@ -615,11 +615,11 @@ class AppEngineWebXmlProcessor {
   }
 
   private void processUrlStreamHandler(Element node, AppEngineWebXml appEngineWebXml) {
-    appEngineWebXml.setUrlStreamHandlerType(getTextNode(node));
+    appEngineWebXml.setUrlStreamHandlerType(XmlUtils.getText(node));
   }
 
   private boolean getBooleanValue(Element node) {
-    return toBoolean(getTextNode(node));
+    return toBoolean(XmlUtils.getText(node));
   }
 
   private boolean getBooleanAttributeValue(Element node, String attribute) {
@@ -629,14 +629,6 @@ class AppEngineWebXmlProcessor {
   private boolean toBoolean(String value) {
     value = value.trim();
     return (value.equalsIgnoreCase("true") || value.equals("1"));
-  }
-
-  private String getTextNode(Element node) {
-    String value = XmlUtils.getBody(node);
-    if (value == null) {
-      value = "";
-    }
-    return value.trim();
   }
 
   private String trim(String attribute) {

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/utils/config/XmlUtils.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/utils/config/XmlUtils.java
@@ -153,7 +153,11 @@ public class XmlUtils {
 
   static String getChildElementBody(Element element, String tagName, boolean required) {
     Element elt = getChildElement(element, tagName, required);
-    return (elt != null) ? getBody(elt) : null;
+    if (elt == null) {
+      return null;
+    }
+    String result = getText(elt);
+    return result.isEmpty() ? null : result;
   }
 
   static Element getOptionalChildElement(Element parent, String tagName) {
@@ -179,20 +183,6 @@ public class XmlUtils {
     } else {
       return element.getAttribute(name);
     }
-  }
-
-  static String getBody(Element element) {
-    NodeList nodes = element.getChildNodes();
-    if (nodes == null || nodes.getLength() == 0) {
-      return null;
-    }
-
-    Node firstNode = nodes.item(0);
-    if (firstNode == null) {
-      return null;
-    }
-
-    return firstNode.getNodeValue();
   }
 
   static List<Element> getChildren(Element element) {

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessorTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessorTest.java
@@ -1,0 +1,2076 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.utils.config;
+
+import com.google.apphosting.utils.config.AppEngineWebXml.AdminConsolePage;
+import com.google.apphosting.utils.config.AppEngineWebXml.ApiConfig;
+import com.google.apphosting.utils.config.AppEngineWebXml.ErrorHandler;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link AppEngineWebXmlProcessor}.
+ */
+public class AppEngineWebXmlProcessorTest extends TestCase {
+
+  private static final String XML_FORMAT =
+      " <appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">"
+          + "<application><!-- ignore -->helloworld-java<!-- ignore as well--></application> "
+          + "</appengine-web-app>";
+
+  private static final String XML_FORMAT_SESSIONS_SSL =
+      " <appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">"
+          + "<application>helloworld-java</application> "
+          + "<version>1</version> "
+          + "<ssl-enabled>true</ssl-enabled>"
+          + "<sessions-enabled>true</sessions-enabled>"
+          + "</appengine-web-app>";
+
+  private AppEngineWebXml getAppEngineWebXml(String content) {
+    File schemaFile =
+        new File("src/test/resources/com/google/apphosting/utils/config/appengine-web.xsd");
+    XmlUtils.validateXmlContent(content, schemaFile);
+    return new AppEngineWebXmlProcessor()
+        .processXml(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  public void testParseGoodXml() {
+    AppEngineWebXml aewx = getAppEngineWebXml(XML_FORMAT);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId(null);
+    expected.setSslEnabled(true);
+    assertEquals(expected, aewx);
+  }
+
+  private AppEngineWebXml newAppEngineWebXml() {
+    AppEngineWebXml result = new AppEngineWebXml();
+    result.setWarmupRequestsEnabled(true);
+    return result;
+  }
+
+  public void testParseSessionSslXml() {
+    AppEngineWebXml aewx = getAppEngineWebXml(XML_FORMAT_SESSIONS_SSL);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setSslEnabled(true);
+    expected.setSessionsEnabled(true);
+    assertEquals(expected, aewx);
+  }
+
+  public void testAsyncSessionPersistence() {
+    doTestAsyncSessionPersistence("queue-name=\"blar\"", "blar");
+  }
+
+  public void testAsyncSessionPersistence_NoQueueName() {
+    doTestAsyncSessionPersistence("", null);
+  }
+
+  private void doTestAsyncSessionPersistence(String queueNameXml, String expectedQueueName) {
+    String xml = String.format(
+        " <appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">"
+            + "<application>helloworld-java</application> "
+            + "<version>1</version> "
+            + "<sessions-enabled>true</sessions-enabled>"
+            + "<async-session-persistence enabled=\"true\" %s/>"
+            + "</appengine-web-app>", queueNameXml);
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    assertFalse(expected.getAsyncSessionPersistence());
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setSslEnabled(true);
+    expected.setSessionsEnabled(true);
+    expected.setAsyncSessionPersistence(true);
+    expected.setAsyncSessionPersistenceQueueName(expectedQueueName);
+    assertEquals(expected, aewx);
+  }
+
+  public void testSslDisabled() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<ssl-enabled>false</ssl-enabled>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setSslEnabled(false);
+    assertEquals(expected, aewx);
+  }
+
+  public void testServerAndInstance() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<service>service1</service>\n"
+            + "<version>1</version>\n"
+            + "<instance-class>F4</instance-class>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setService("service1");
+    expected.setInstanceClass("F4");
+    assertEquals(expected, aewx);
+  }
+
+  public void testModuleIsAllowed() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<module>service1</module>\n"
+            + "<version>1</version>\n"
+            + "<instance-class>F4</instance-class>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setModule("service1");
+    expected.setInstanceClass("F4");
+    assertEquals(expected, aewx);
+    assertEquals("service1", aewx.getModule());
+  }
+
+  public void testErrorWhenServiceAndModuleAreDefined() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<module>service1</module>\n"
+            + "<service>service2</service>\n"
+            + "<version>1</version>\n"
+            + "<instance-class>F4</instance-class>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      getAppEngineWebXml(xml);
+      fail("Expected AppEngineConfigException.");
+    } catch (AppEngineConfigException ex) {
+      // expected
+    }
+  }
+
+  public void testParseUserPermissions() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<user-permissions>\n"
+            + "<permission class=\"com.foo.FooPermission\" name=\"foo\"/>\n"
+            + "<permission class=\"com.foo.FooPermission\" name=\"bar\" actions=\"baz,qux\"/>\n"
+            + "</user-permissions>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.addUserPermission("com.foo.FooPermission", "foo", null);
+    expected.addUserPermission("com.foo.FooPermission", "bar", "baz,qux");
+    assertEquals(expected, aewx);
+  }
+
+  public void testParseInvalidUserPermissions() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<user-permissions>\n"
+            + "<permission class=\"java.io.FilePermission\" name=\"-\" actions=\"read\"/>\n"
+            + "</user-permissions>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      getAppEngineWebXml(xml);
+      fail("Expected AppEngineConfigException.");
+    } catch (AppEngineConfigException ex) {
+      // expected
+    }
+  }
+
+  public void testParseBadXml() {
+    String badXml =
+        " <appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">"
+            + "<blarg></notblarg>"
+            + "</appengine-web-app>";
+
+    try {
+      getAppEngineWebXml(badXml);
+      fail("expected rte");
+    } catch (AppEngineConfigException rte) {
+      // good
+    }
+  }
+
+  public void testParsePublicRoot() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<public-root>/foobar</public-root>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setPublicRoot("/foobar");
+    assertEquals(expected, aewx);
+  }
+
+  public void testParseInvalidPublicRoot() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<public-root>*.html</public-root>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      getAppEngineWebXml(xml);
+      fail("Expected AppEngineConfigException.");
+    } catch (AppEngineConfigException ex) {
+      // expected
+    }
+  }
+
+  public void testParseNoInboundServices() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<inbound-services/>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertEquals(Collections.singleton("warmup"), aewx.getInboundServices());
+  }
+
+  public void testParseOneInboundService() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<inbound-services>\n"
+            + "  <service>xmpp_message</service>\n"
+            + "</inbound-services>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    Set<String> expected = new HashSet<>();
+    expected.add("warmup");
+    expected.add("xmpp_message");
+    assertEquals(expected, aewx.getInboundServices());
+  }
+
+  public void testParseTwoInboundServices() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<inbound-services>\n"
+            + "  <service>mail</service>\n"
+            + "  <service>xmpp_message</service>\n"
+            + "</inbound-services>\n"
+            + "</appengine-web-app>\n";
+
+    Set<String> expected = new HashSet<>();
+    expected.add("warmup");
+    expected.add("mail");
+    expected.add("xmpp_message");
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertEquals(expected, aewx.getInboundServices());
+  }
+
+  public void testStaticInclude() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<static-files>\n"
+            + "  <include path=\"**.nocache.**\" expiration=\"8d\"/>\n"
+            + "  <include path=\"**\"/>\n"
+            + "</static-files>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertEquals(2, aewx.getStaticFileIncludes().size());
+    Iterator<AppEngineWebXml.StaticFileInclude> it = aewx.getStaticFileIncludes().iterator();
+    assertEquals(new AppEngineWebXml.StaticFileInclude("**.nocache.**", "8d"), it.next());
+    assertEquals(new AppEngineWebXml.StaticFileInclude("**", null), it.next());
+  }
+
+  public void testStaticIncludeWithZeroExpiration() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<static-files>\n"
+            + "  <include path=\"**.nocache.**\" expiration=\"0\"/>\n"
+            + "  <include path=\"**\"/>\n"
+            + "</static-files>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertEquals(2, aewx.getStaticFileIncludes().size());
+    Iterator<AppEngineWebXml.StaticFileInclude> it = aewx.getStaticFileIncludes().iterator();
+    assertEquals(new AppEngineWebXml.StaticFileInclude("**.nocache.**", "0"), it.next());
+    assertEquals(new AppEngineWebXml.StaticFileInclude("**", null), it.next());
+  }
+
+  public void testStaticIncludeWithHttpHeaders() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>all-your-base</application>\n"
+            + "<version>1</version>\n"
+            + "<static-files>\n"
+            + "  <include path=\"/static-files/*\">\n"
+            + "    <http-header name=\"Bomb-Planter\" value=\"somebody\"/>\n"
+            + "    <http-header name=\"Chance-To-Survive\" value=\"no\"/>\n"
+            + "  </include>\n"
+            + "</static-files>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+
+    assertEquals(1, aewx.getStaticFileIncludes().size());
+    Map<String, String> httpHeaders = aewx.getStaticFileIncludes().get(0).getHttpHeaders();
+    assertEquals(2, httpHeaders.size());
+    assertEquals("somebody", httpHeaders.get("Bomb-Planter"));
+    assertEquals("no", httpHeaders.get("Chance-To-Survive"));
+  }
+
+  public void testPrecompilationEnabled() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<precompilation-enabled>true</precompilation-enabled>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setPrecompilationEnabled(true);
+    assertEquals(expected, aewx);
+  }
+
+  public void testThreadsafe() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<threadsafe>true</threadsafe>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertTrue(aewx.getThreadsafeValueProvided());
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setThreadsafe(true);
+    assertEquals(expected, aewx);
+  }
+
+  public void testAutoIdPolicy() {
+    for (String policy : Arrays.asList("legacy", "default")) {
+      String xml =
+          "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+              + "<application>helloworld-java</application>\n"
+              + "<version>1</version>\n"
+              + "<auto-id-policy>" + policy + "</auto-id-policy>"
+              + "</appengine-web-app>\n";
+
+      AppEngineWebXml aewx = getAppEngineWebXml(xml);
+      assertNotNull(aewx);
+      AppEngineWebXml expected = newAppEngineWebXml();
+      expected.setAppId("helloworld-java");
+      expected.setMajorVersionId("1");
+      expected.setAutoIdPolicy(policy);
+      assertEquals(expected, aewx);
+    }
+  }
+
+  public void testCodeLock() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<code-lock>true</code-lock>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setCodeLock(true);
+    assertEquals(expected, aewx);
+  }
+
+  public void testVmRuntime() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<vm>true</vm>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setUseVm(true);
+    assertEquals(expected, aewx);
+  }
+
+  public void testEnv() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<env>1</env>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setEnv("1");
+    assertEquals(expected, aewx);
+  }
+
+  public void testBetaSettings() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<vm>true</vm>\n"
+            + "<beta-settings>\n"
+            + "  <setting name=\"machine_type\" value=\"n1-standard-1\"/>\n"
+            + "  <setting name=\"health_check_enabled\" value=\"on\"/>\n"
+            + "  <setting name=\"health_check_restart_timeout\" value=\"600\"/>\n"
+            + "  <setting name=\"root_setup_command\" value=\"/bin/bash {app_name}/setup.sh\"/>\n"
+            + "</beta-settings>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setUseVm(true);
+    expected.addBetaSetting("machine_type", "n1-standard-1");
+    expected.addBetaSetting("health_check_enabled", "on");
+    expected.addBetaSetting("health_check_restart_timeout", "600");
+    expected.addBetaSetting("root_setup_command", "/bin/bash {app_name}/setup.sh");
+    assertEquals(expected, aewx);
+  }
+
+  public void testAdminConsolePages() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<admin-console>"
+            + "<page name=\"foo\" url=\"/bar\"/>"
+            + "<page name=\"baz\" url=\"/bax\"/>"
+            + "</admin-console>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.addAdminConsolePage(new AdminConsolePage("foo", "/bar"));
+    expected.addAdminConsolePage(new AdminConsolePage("baz", "/bax"));
+    assertEquals(expected, aewx);
+  }
+
+  public void testErrorHandlers() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<static-error-handlers>"
+            + "<handler file=\"ohno.html\"/>"
+            + "<handler file=\"timeout.html\" error-code=\"timeout\"/>"
+            + "</static-error-handlers>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.addErrorHandler(new ErrorHandler("ohno.html", null));
+    expected.addErrorHandler(new ErrorHandler("timeout.html", "timeout"));
+    assertEquals(expected, aewx);
+  }
+
+  public void testWarmupRequestsDefault() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertTrue(aewx.getWarmupRequestsEnabled());
+    assertEquals(Collections.singleton("warmup"), aewx.getInboundServices());
+  }
+
+  public void testWarmupRequestsTrue() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<warmup-requests-enabled>true</warmup-requests-enabled>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertTrue(aewx.getWarmupRequestsEnabled());
+    assertEquals(Collections.singleton("warmup"), aewx.getInboundServices());
+  }
+
+  public void testWarmupRequestsFalse() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<warmup-requests-enabled>false</warmup-requests-enabled>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertFalse(aewx.getWarmupRequestsEnabled());
+    assertEquals(Collections.emptySet(), aewx.getInboundServices());
+  }
+
+  public void testApiConfig() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<api-config servlet-class=\"foo.ConfigServlet\" url-pattern=\"/my/api\">\n"
+            + "</api-config>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setApiConfig(new ApiConfig("foo.ConfigServlet", "/my/api"));
+    assertEquals(expected, aewx);
+  }
+
+  public void testApiEndpoint() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<api-config servlet-class=\"foo.ConfigServlet\" url-pattern=\"/my/api\">\n"
+            + "<endpoint-servlet-mapping-id>endpoint-1</endpoint-servlet-mapping-id>\n"
+            + "</api-config>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setApiConfig(new ApiConfig("foo.ConfigServlet", "/my/api"));
+    expected.addApiEndpoint("endpoint-1");
+    assertTrue(aewx.isApiEndpoint("endpoint-1"));
+    assertEquals(expected, aewx);
+  }
+
+  public void testMultipleApiEndpoints() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<api-config servlet-class=\"foo.ConfigServlet\" url-pattern=\"/my/api\">\n"
+            + "<endpoint-servlet-mapping-id>endpoint-1</endpoint-servlet-mapping-id>\n"
+            + "<endpoint-servlet-mapping-id>endpoint-foo</endpoint-servlet-mapping-id>\n"
+            + "<endpoint-servlet-mapping-id>endpoint-bar</endpoint-servlet-mapping-id>\n"
+            + "</api-config>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setApiConfig(new ApiConfig("foo.ConfigServlet", "/my/api"));
+    expected.addApiEndpoint("endpoint-1");
+    assertTrue(aewx.isApiEndpoint("endpoint-1"));
+    expected.addApiEndpoint("endpoint-foo");
+    assertTrue(aewx.isApiEndpoint("endpoint-foo"));
+    expected.addApiEndpoint("endpoint-bar");
+    assertTrue(aewx.isApiEndpoint("endpoint-bar"));
+    assertEquals(expected, aewx);
+  }
+
+  public void testWhitespaceIsTrimmed() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<public-root>\n\n \n/root\n \n </public-root>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertEquals("/root", aewx.getPublicRoot());
+  }
+
+  private AppEngineWebXml.AutomaticScaling parseAndGetAutomaticScaling(String xml) {
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertNotNull(aewx.getAutomaticScaling());
+    AppEngineWebXml.AutomaticScaling settings = aewx.getAutomaticScaling();
+    assertTrue(aewx.getManualScaling().isEmpty());
+    assertTrue(aewx.getBasicScaling().isEmpty());
+    return settings;
+  }
+
+  public void testAutomaticScaling_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getMinPendingLatency());
+    assertNull(settings.getMaxPendingLatency());
+    assertNull(settings.getMaxIdleInstances());
+    assertNull(settings.getMinIdleInstances());
+    assertNull(settings.getMinNumInstances());
+    assertNull(settings.getMaxNumInstances());
+    assertNull(settings.getCoolDownPeriodSec());
+    assertNull(settings.getCpuUtilization());
+  }
+
+  public void testAutomaticScaling_idleInstancesAutomatic() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-idle-instances>automatic</min-idle-instances>\n"
+            + " <max-idle-instances>automatic</max-idle-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("automatic", settings.getMinIdleInstances());
+    assertEquals("automatic", settings.getMaxIdleInstances());
+  }
+
+  public void testAutomaticScaling_idleInstances() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-idle-instances>2</min-idle-instances>\n"
+            + " <max-idle-instances>3</max-idle-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("2", settings.getMinIdleInstances());
+    assertEquals("3", settings.getMaxIdleInstances());
+  }
+
+  public void testAutomaticScaling_pendingLatencyAutomatic() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-pending-latency>automatic</min-pending-latency>\n"
+            + " <max-pending-latency>automatic</max-pending-latency>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("automatic", settings.getMinPendingLatency());
+    assertEquals("automatic", settings.getMaxPendingLatency());
+  }
+
+  public void testAutomaticScaling_pendingLatency() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-pending-latency>2.2s</min-pending-latency>\n"
+            + " <max-pending-latency>3000ms</max-pending-latency>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("2.2s", settings.getMinPendingLatency());
+    assertEquals("3000ms", settings.getMaxPendingLatency());
+  }
+
+  public void testAutomaticScaling_maxConcurrentRequests() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <max-concurrent-requests>20</max-concurrent-requests>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("20", settings.getMaxConcurrentRequests());
+  }
+
+  public void testAutomaticScaling_minNumInstances_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances></min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail("Should fail due to incorrect min-num-instances");
+    } catch (AppEngineConfigException expected) {
+    }
+
+    xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances>   </min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail("Should fail due to incorrect min-num-instances");
+    } catch (AppEngineConfigException expected) {
+    }
+
+    xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances> \t \n </min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail("Should fail due to incorrect min-num-instances");
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_minNumInstances_valid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances>2</min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(2, settings.getMinNumInstances().intValue());
+  }
+
+  public void testAutomaticScaling_minNumInstances_zero() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances>0</min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_minNumInstances_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances>-2</min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_minNumInstances_string() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <min-num-instances>123abc</min-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_maxNumInstances_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getMaxNumInstances());
+  }
+
+  public void testAutomaticScaling_maxNumInstances_zero() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <max-num-instances>0</max-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_maxNumInstances_valid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <max-num-instances>15</max-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(15, settings.getMaxNumInstances().intValue());
+  }
+
+  public void testAutomaticScaling_maxNumInstances_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <max-num-instances>-5</max-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_maxNumInstances_string() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <max-num-instances>123abc</max-num-instances>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_coolDownPeriodSec_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getCoolDownPeriodSec());
+
+    xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getCoolDownPeriodSec());
+  }
+
+  public void testAutomaticScaling_coolDownPeriodSec_valid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cool-down-period-sec>25</cool-down-period-sec>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(25, settings.getCoolDownPeriodSec().intValue());
+  }
+
+  public void testAutomaticScaling_coolDownPeriodSec_zero() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cool-down-period-sec>0</cool-down-period-sec>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_coolDownPeriodSec_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cool-down-period-sec>-25</cool-down-period-sec>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_coolDownPeriodSec_string() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cool-down-period-sec>123abc</cool-down-period-sec>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getCpuUtilization());
+  }
+
+  public void testAutomaticScaling_cpuUtilization_targetUtilization_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getCpuUtilization());
+  }
+
+  public void testAutomaticScaling_cpuUtilization_targetUtilization_valid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <target-utilization>0.5</target-utilization>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(0.5, settings.getCpuUtilization().getTargetUtilization().doubleValue());
+  }
+
+  public void testAutomaticScaling_cpuUtilization_targetUtilization_zero() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <target-utilization>0</target-utilization>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_targetUtilization_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <target-utilization>-0.5</target-utilization>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_targetUtilization_moreThanOne() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <target-utilization>1.1</target-utilization>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_targetUtilization_string() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <target-utilization>0.5adc</target-utilization>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_aggregationWindowLengthSec_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getCpuUtilization());
+  }
+
+  public void testAutomaticScaling_cpuUtilization_aggregationWindowLengthSec_valid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <aggregation-window-length-sec>35</aggregation-window-length-sec>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.AutomaticScaling settings = parseAndGetAutomaticScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(35, settings.getCpuUtilization().getAggregationWindowLengthSec().intValue());
+  }
+
+  public void testAutomaticScaling_cpuUtilization_aggregationWindowLengthSec_zero() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <aggregation-window-length-sec>0</aggregation-window-length-sec>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_aggregationWindowLengthSec_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <aggregation-window-length-sec>-5</aggregation-window-length-sec>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testAutomaticScaling_cpuUtilization_aggregationWindowLengthSec_string() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<automatic-scaling>\n"
+            + " <cpu-utilization>\n"
+            + "   <aggregation-window-length-sec>5abc</aggregation-window-length-sec>\n"
+            + " </cpu-utilization>\n"
+            + "</automatic-scaling>\n"
+            + "</appengine-web-app>\n";
+    try {
+      parseAndGetAutomaticScaling(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  private AppEngineWebXml.ManualScaling parseAngGetManualScaling(String xml) {
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertNotNull(aewx.getManualScaling());
+    AppEngineWebXml.ManualScaling settings = aewx.getManualScaling();
+    assertTrue(aewx.getAutomaticScaling().isEmpty());
+    assertTrue(aewx.getBasicScaling().isEmpty());
+    return settings;
+  }
+
+  public void testManualScaling_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<manual-scaling>\n"
+            + " <instances>           </instances>\n"
+            + "</manual-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.ManualScaling settings = parseAngGetManualScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getInstances());
+  }
+
+  public void testManualScaling_instances() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<manual-scaling>\n"
+            + " <instances>10</instances>\n"
+            + "</manual-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.ManualScaling settings = parseAngGetManualScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("10", settings.getInstances());
+  }
+
+  private AppEngineWebXml.BasicScaling parseAngGetBasicScaling(String xml) {
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertNotNull(aewx.getBasicScaling());
+    AppEngineWebXml.BasicScaling settings = aewx.getBasicScaling();
+    assertTrue(aewx.getAutomaticScaling().isEmpty());
+    assertTrue(aewx.getManualScaling().isEmpty());
+    return settings;
+  }
+
+  public void testBasicScaling_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<basic-scaling>\n"
+            + " <max-instances>           </max-instances>\n"
+            + " <idle-timeout>           </idle-timeout>\n"
+            + "</basic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.BasicScaling settings = parseAngGetBasicScaling(xml);
+    assertTrue(settings.isEmpty());
+    assertNull(settings.getIdleTimeout());
+  }
+
+  public void testBasicScaling_maxInstances() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<basic-scaling>\n"
+            + " <max-instances>11</max-instances>\n"
+            + "</basic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.BasicScaling settings = parseAngGetBasicScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("11", settings.getMaxInstances());
+    assertEquals(null, settings.getIdleTimeout());
+  }
+
+  public void testBasicScaling_maxInstancesAndIdleTimeout() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<basic-scaling>\n"
+            + " <max-instances>11</max-instances>\n"
+            + " <idle-timeout>10m</idle-timeout>\n"
+            + "</basic-scaling>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.BasicScaling settings = parseAngGetBasicScaling(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals("11", settings.getMaxInstances());
+    assertEquals("10m", settings.getIdleTimeout());
+  }
+
+  private AppEngineWebXml.HealthCheck parseAngGetHealthCheck(String xml) {
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertNotNull(aewx.getHealthCheck());
+    AppEngineWebXml.HealthCheck settings = aewx.getHealthCheck();
+    return settings;
+  }
+
+  public void testHealthCheck_noSetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertTrue(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_emptySetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertTrue(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_enableHealthCheck_noSetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertTrue(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_enableHealthCheck_empty() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertTrue(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_enableHealthCheck_false() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <enable-health-check>false</enable-health-check>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(false, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_enableHealthCheck_true() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <enable-health-check>true</enable-health-check>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertTrue(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_getCheckIntervalSec() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <check-interval-sec>5</check-interval-sec>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(5, settings.getCheckIntervalSec().intValue());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_getCheckIntervalSec_invalid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <check-interval-sec>123abc</check-interval-sec>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getCheckIntervalSec_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <check-interval-sec>-1</check-interval-sec>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getTimeoutSec() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <timeout-sec>6</timeout-sec>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(6, settings.getTimeoutSec().intValue());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_getTimeoutSec_invalid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <timeout-sec>123abc</timeout-sec>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getTimeoutSec_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <timeout-sec>-1</timeout-sec>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getUnhealthyThreshold() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <unhealthy-threshold>7</unhealthy-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(7, settings.getUnhealthyThreshold().intValue());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_getUnhealthyThreshold_invalid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <unhealthy-threshold>123abc</unhealthy-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getUnhealthyThreshold_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <unhealthy-threshold>-1</unhealthy-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getHealthyThreshold() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <healthy-threshold>8</healthy-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(8, settings.getHealthyThreshold().intValue());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_getHealthyThreshold_invalid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <healthy-threshold>123abc</healthy-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getHealthyThreshold_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <healthy-threshold>-1</healthy-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getRestartThreshold() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <restart-threshold>9</restart-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(9, settings.getRestartThreshold().intValue());
+    assertEquals(null, settings.getHost());
+  }
+
+  public void testHealthCheck_getRestartThreshold_invalid() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <restart-threshold>123abc</restart-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getRestartThreshold_negative() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <restart-threshold>-1</restart-threshold>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+
+    try {
+      parseAngGetHealthCheck(xml);
+      fail();
+    } catch (AppEngineConfigException expected) {
+    }
+  }
+
+  public void testHealthCheck_getHost() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <host>test.com</host>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(true, settings.getEnableHealthCheck());
+    assertEquals(null, settings.getCheckIntervalSec());
+    assertEquals(null, settings.getTimeoutSec());
+    assertEquals(null, settings.getUnhealthyThreshold());
+    assertEquals(null, settings.getHealthyThreshold());
+    assertEquals(null, settings.getRestartThreshold());
+    assertEquals("test.com", settings.getHost());
+  }
+
+  public void testHealthCheck_allSettings() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<health-check>\n"
+            + " <enable-health-check>false</enable-health-check>\n"
+            + " <check-interval-sec>5</check-interval-sec>\n"
+            + " <timeout-sec>6</timeout-sec>\n"
+            + " <unhealthy-threshold>7</unhealthy-threshold>\n"
+            + " <healthy-threshold>8</healthy-threshold>\n"
+            + " <restart-threshold>9</restart-threshold>\n"
+            + " <host>test.com</host>\n"
+            + "</health-check>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
+    assertFalse(settings.isEmpty());
+    assertEquals(false, settings.getEnableHealthCheck());
+    assertEquals(5, settings.getCheckIntervalSec().intValue());
+    assertEquals(6, settings.getTimeoutSec().intValue());
+    assertEquals(7, settings.getUnhealthyThreshold().intValue());
+    assertEquals(8, settings.getHealthyThreshold().intValue());
+    assertEquals(9, settings.getRestartThreshold().intValue());
+    assertEquals("test.com", settings.getHost());
+  }
+
+  private AppEngineWebXml.Resources parseAndGetResources(String xml) {
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertNotNull(aewx.getResources());
+    AppEngineWebXml.Resources resources = aewx.getResources();
+    return resources;
+  }
+
+  private AppEngineWebXml.Network parseAndGetNetwork(String xml) {
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    assertNotNull(aewx.getNetwork());
+    AppEngineWebXml.Network network = aewx.getNetwork();
+    return network;
+  }
+
+  public void testResources_NoSetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Resources resources = parseAndGetResources(xml);
+    assertTrue(resources.isEmpty());
+  }
+
+  public void testResources_EmptySetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<resources>\n"
+            + "</resources>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Resources resources = parseAndGetResources(xml);
+    assertTrue(resources.isEmpty());
+  }
+
+  public void testResources_Cpu() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<resources>\n"
+            + "<cpu>2.5</cpu>\n"
+            + "</resources>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Resources resources = parseAndGetResources(xml);
+    assertEquals(resources.getCpu(), 2.5);
+  }
+
+  public void testResources_MemoryGb() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<resources>\n"
+            + "<memory-gb>25</memory-gb>\n"
+            + "</resources>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Resources resources = parseAndGetResources(xml);
+    assertEquals(resources.getMemoryGb(), 25.0);
+  }
+
+  public void testResources_DiskSizeGb() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<resources>\n"
+            + "<disk-size-gb>250</disk-size-gb>\n"
+            + "</resources>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Resources resources = parseAndGetResources(xml);
+    assertEquals(resources.getDiskSizeGb(), 250);
+  }
+
+  public void testResources_Full() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<resources>\n"
+            + "<cpu>2.5</cpu>\n"
+            + "<memory-gb>25</memory-gb>\n"
+            + "<disk-size-gb>250</disk-size-gb>\n"
+            + "</resources>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Resources resources = parseAndGetResources(xml);
+    assertEquals(resources.getCpu(), 2.5);
+    assertEquals(resources.getMemoryGb(), 25.0);
+    assertEquals(resources.getDiskSizeGb(), 250);
+  }
+
+  public void testNetwork_NoSetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Network network = parseAndGetNetwork(xml);
+    assertTrue(network.isEmpty());
+  }
+
+  public void testNetwork_EmptySetting() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<network>\n"
+            + "</network>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Network network = parseAndGetNetwork(xml);
+    assertTrue(network.isEmpty());
+  }
+
+  public void testNetwork_InstanceTag() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<network>\n"
+            + "<instance-tag>mytag</instance-tag>\n"
+            + "</network>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Network network = parseAndGetNetwork(xml);
+    assertEquals(network.getInstanceTag(), "mytag");
+  }
+
+  public void testNetwork_ForwardedPorts() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<network>\n"
+            + "<forwarded-port>myport1</forwarded-port>"
+            + "<forwarded-port>myport2</forwarded-port>"
+            + "<forwarded-port>myport3:myport4</forwarded-port>"
+            + "</network>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Network network = parseAndGetNetwork(xml);
+    assertEquals(network.getForwardedPorts().size(), 3);
+    assertEquals(network.getForwardedPorts().get(0), "myport1");
+    assertEquals(network.getForwardedPorts().get(1), "myport2");
+    assertEquals(network.getForwardedPorts().get(2), "myport3:myport4");
+  }
+
+  public void testNetwork_Name() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<network>\n"
+            + "<name>mynetwork</name>"
+            + "</network>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Network network = parseAndGetNetwork(xml);
+    assertEquals(network.getName(), "mynetwork");
+  }
+
+  public void testNetwork_Full() {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<network>\n"
+            + "<forwarded-port>myport1</forwarded-port>"
+            + "<forwarded-port>myport2</forwarded-port>"
+            + "<instance-tag>mytag</instance-tag>\n"
+            + "<name>mynetwork</name>"
+            + "</network>\n"
+            + "</appengine-web-app>\n";
+    AppEngineWebXml.Network network = parseAndGetNetwork(xml);
+    assertEquals(network.getForwardedPorts().size(), 2);
+    assertEquals(network.getForwardedPorts().get(0), "myport1");
+    assertEquals(network.getForwardedPorts().get(1), "myport2");
+    assertEquals(network.getName(), "mynetwork");
+  }
+
+  private void runConflictingScalingTest(String xml) throws Exception {
+    String fullXml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + xml
+            + "</appengine-web-app>\n";
+    try {
+      getAppEngineWebXml(fullXml);
+      fail("AppEngineConfigException expected.");
+    } catch (AppEngineConfigException e) {
+      assertTrue(e.toString().contains("only one of 'automatic-scaling',"));
+    }
+  }
+
+  public void testConflictingScaling_AutomaticBasic() throws Exception {
+    String xml =
+        "<basic-scaling>\n"
+            + " <max-instances>11</max-instances>\n"
+            + "</basic-scaling>\n"
+            + "<automatic-scaling>\n"
+            + " <max-idle-instances>11</max-idle-instances>\n"
+            + "</automatic-scaling>\n";
+    runConflictingScalingTest(xml);
+  }
+
+  public void testConflictingScaling_ManualAutomatic() throws Exception {
+    String xml =
+        "<manual-scaling>\n"
+            + " <instances>11</instances>\n"
+            + "</manual-scaling>\n"
+            + "<automatic-scaling>\n"
+            + " <max-idle-instances>11</max-idle-instances>\n"
+            + "</automatic-scaling>\n";
+    runConflictingScalingTest(xml);
+  }
+
+  public void testConflictingScaling_ManualBasic() throws Exception {
+    String xml =
+        "<manual-scaling>\n"
+            + " <instances>11</instances>\n"
+            + "</manual-scaling>\n"
+            + "<basic-scaling>\n"
+            + " <max-instances>11</max-instances>\n"
+            + "</basic-scaling>\n";
+    runConflictingScalingTest(xml);
+  }
+
+  private AppEngineWebXml parseUrlStreamHandlerType(String streamHandlerType) {
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>gianni-app</application>\n"
+            + "<version>1</version>\n"
+            + "<url-stream-handler>" + streamHandlerType + "</url-stream-handler>\n"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    return aewx;
+  }
+
+  public void testUrlStreamHandler() {
+    assertEquals("native", parseUrlStreamHandlerType("native").getUrlStreamHandlerType());
+    assertEquals("urlfetch", parseUrlStreamHandlerType("urlfetch").getUrlStreamHandlerType());
+    assertTrue(parseUrlStreamHandlerType("native").toString()
+        .contains("urlStreamHandlerType=native"));
+    try {
+      parseUrlStreamHandlerType("fail here");
+      fail("Expected an AppEngineConfigException exception.");
+    } catch (AppEngineConfigException e) {
+      // pass
+    }
+  }
+
+  public void testUseGoogleConnectorJ() {
+    // Enabled explicitly
+    String xml =
+        "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+            + "<application>helloworld-java</application>\n"
+            + "<version>1</version>\n"
+            + "<use-google-connector-j>true</use-google-connector-j>"
+            + "</appengine-web-app>\n";
+
+    AppEngineWebXml aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    AppEngineWebXml expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setUseGoogleConnectorJ(true);
+    assertEquals(expected, aewx);
+
+    // Disabled explicitly
+    xml = "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+        + "<application>helloworld-java</application>\n"
+        + "<version>1</version>\n"
+        + "<use-google-connector-j>false</use-google-connector-j>"
+        + "</appengine-web-app>\n";
+
+    aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    expected.setUseGoogleConnectorJ(false);
+    assertEquals(expected, aewx);
+
+    // No set in the XML
+    xml = "<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n"
+        + "<application>helloworld-java</application>\n"
+        + "<version>1</version>\n"
+        + "</appengine-web-app>\n";
+
+    aewx = getAppEngineWebXml(xml);
+    assertNotNull(aewx);
+    expected = newAppEngineWebXml();
+    expected.setAppId("helloworld-java");
+    expected.setMajorVersionId("1");
+    assertEquals(expected, aewx);
+  }
+}

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessorTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlProcessorTest.java
@@ -1318,7 +1318,7 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
     AppEngineWebXml.BasicScaling settings = parseAngGetBasicScaling(xml);
     assertFalse(settings.isEmpty());
     assertEquals("11", settings.getMaxInstances());
-    assertEquals(null, settings.getIdleTimeout());
+    assertNull(settings.getIdleTimeout());
   }
 
   public void testBasicScaling_maxInstancesAndIdleTimeout() {
@@ -1353,13 +1353,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertTrue(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_emptySetting() {
@@ -1372,13 +1372,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertTrue(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_enableHealthCheck_noSetting() {
@@ -1391,13 +1391,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertTrue(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_enableHealthCheck_empty() {
@@ -1410,13 +1410,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertTrue(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_enableHealthCheck_false() {
@@ -1430,13 +1430,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(false, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertFalse(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_enableHealthCheck_true() {
@@ -1450,13 +1450,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertTrue(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_getCheckIntervalSec() {
@@ -1470,13 +1470,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
+    assertTrue(settings.getEnableHealthCheck());
     assertEquals(5, settings.getCheckIntervalSec().intValue());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_getCheckIntervalSec_invalid() {
@@ -1524,13 +1524,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
     assertEquals(6, settings.getTimeoutSec().intValue());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_getTimeoutSec_invalid() {
@@ -1578,13 +1578,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
     assertEquals(7, settings.getUnhealthyThreshold().intValue());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_getUnhealthyThreshold_invalid() {
@@ -1632,13 +1632,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
     assertEquals(8, settings.getHealthyThreshold().intValue());
-    assertEquals(null, settings.getRestartThreshold());
-    assertEquals(null, settings.getHost());
+    assertNull(settings.getRestartThreshold());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_getHealthyThreshold_invalid() {
@@ -1686,13 +1686,13 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
     assertEquals(9, settings.getRestartThreshold().intValue());
-    assertEquals(null, settings.getHost());
+    assertNull(settings.getHost());
   }
 
   public void testHealthCheck_getRestartThreshold_invalid() {
@@ -1740,12 +1740,12 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(true, settings.getEnableHealthCheck());
-    assertEquals(null, settings.getCheckIntervalSec());
-    assertEquals(null, settings.getTimeoutSec());
-    assertEquals(null, settings.getUnhealthyThreshold());
-    assertEquals(null, settings.getHealthyThreshold());
-    assertEquals(null, settings.getRestartThreshold());
+    assertTrue(settings.getEnableHealthCheck());
+    assertNull(settings.getCheckIntervalSec());
+    assertNull(settings.getTimeoutSec());
+    assertNull(settings.getUnhealthyThreshold());
+    assertNull(settings.getHealthyThreshold());
+    assertNull(settings.getRestartThreshold());
     assertEquals("test.com", settings.getHost());
   }
 
@@ -1766,7 +1766,7 @@ public class AppEngineWebXmlProcessorTest extends TestCase {
             + "</appengine-web-app>\n";
     AppEngineWebXml.HealthCheck settings = parseAngGetHealthCheck(xml);
     assertFalse(settings.isEmpty());
-    assertEquals(false, settings.getEnableHealthCheck());
+    assertFalse(settings.getEnableHealthCheck());
     assertEquals(5, settings.getCheckIntervalSec().intValue());
     assertEquals(6, settings.getTimeoutSec().intValue());
     assertEquals(7, settings.getUnhealthyThreshold().intValue());

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlReaderTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlReaderTest.java
@@ -90,7 +90,7 @@ public class AppEngineWebXmlReaderTest extends TestCase {
     AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
     assertEquals("myapp", aeWebXml.getAppId());
     assertEquals("1", aeWebXml.getMajorVersionId());
-    assertEquals(true, aeWebXml.getSslEnabled());
+    assertTrue(aeWebXml.getSslEnabled());
     assertTrue(aeWebXml.getThreadsafeValueProvided());
   }
 
@@ -148,7 +148,7 @@ public class AppEngineWebXmlReaderTest extends TestCase {
     AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
     assertEquals("", aeWebXml.getAppId());
     assertEquals("", aeWebXml.getMajorVersionId());
-    assertEquals(false, aeWebXml.getSslEnabled());
+    assertFalse(aeWebXml.getSslEnabled());
   }
 
   public void testMinimal() {

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlReaderTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlReaderTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.utils.config;
+
+import com.google.apphosting.utils.config.AppEngineWebXml.ClassLoaderConfig;
+import com.google.apphosting.utils.config.AppEngineWebXml.PrioritySpecifierEntry;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Unit tests for {@link AppEngineWebXmlReader}.
+ */
+public class AppEngineWebXmlReaderTest extends TestCase {
+
+  private static final String APP_ENGINE_WEB_XML_FORMAT =
+      "src/test/resources/%s/%s_appengine-web.xml";
+
+  private String getFilenameToParse(String testName) {
+    String packagePath = getClass().getPackage().getName().replace('.', '/');
+    return String.format(APP_ENGINE_WEB_XML_FORMAT, packagePath, testName);
+  }
+
+  public void testNonexistentFileThrowsAppEngineConfigException() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return "does not exist";
+      }
+    };
+
+    try {
+      reader.readAppEngineWebXml();
+      fail("expected AppEngineConfigException");
+    } catch (AppEngineConfigException e) {
+      // good
+    }
+  }
+
+  public void testExplosiveXmlProcessingThrowsAppEngineConfigException() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+
+      @Override
+      protected InputStream getInputStream() {
+        return new ByteArrayInputStream(new byte[0]);
+      }
+
+      @Override
+      protected AppEngineWebXml processXml(InputStream is) {
+        throw new RuntimeException("ka-boom");
+      }
+    };
+    try {
+      reader.readAppEngineWebXml();
+      fail("expected AppEngineConfigException");
+    } catch (AppEngineConfigException e) {
+      // good
+      assertEquals("ka-boom", e.getCause().getMessage());
+    }
+  }
+
+  public void testValid() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("Valid");
+      }
+    };
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertEquals("myapp", aeWebXml.getAppId());
+    assertEquals("1", aeWebXml.getMajorVersionId());
+    assertEquals(true, aeWebXml.getSslEnabled());
+    assertTrue(aeWebXml.getThreadsafeValueProvided());
+  }
+
+  public void testClassLoaderConfig() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("ClassLoaderConfig");
+      }
+    };
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    ClassLoaderConfig config = aeWebXml.getClassLoaderConfig();
+    assertNotNull(config);
+    List<PrioritySpecifierEntry> entries = config.getEntries();
+    assertNotNull(entries);
+    assertEquals(1, entries.size());
+    PrioritySpecifierEntry entry = entries.get(0);
+    assertEquals("mailapi.jar", entry.getFilename());
+    assertEquals(-1.0d, entry.getPriority());
+  }
+
+  public void testUrlStreamHandlerDefaultConfig() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("Minimal");
+      }
+    };
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertNull(aeWebXml.getUrlStreamHandlerType());
+  }
+
+  public void testUrlStreamHandlerNativeConfig() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("UrlStreamHandler");
+      }
+    };
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertEquals("native", aeWebXml.getUrlStreamHandlerType());
+  }
+
+  public void testEmptyAppId() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("Empty");
+      }
+    };
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertEquals("", aeWebXml.getAppId());
+    assertEquals("", aeWebXml.getMajorVersionId());
+    assertEquals(false, aeWebXml.getSslEnabled());
+  }
+
+  public void testMinimal() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("Minimal");
+      }
+    };
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertEquals("myapp", aeWebXml.getAppId());
+    assertEquals("1", aeWebXml.getMajorVersionId());
+  }
+
+  public void testMissingThreadsafeElement() {
+    // First test the default behavior, which is that threadsafe is required.
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("NoThreadsafe");
+      }
+    };
+
+    try {
+      reader.readAppEngineWebXml();
+    } catch (AppEngineConfigException aece) {
+      assertTrue(aece.getMessage().startsWith(
+          "appengine-web.xml does not contain a <threadsafe> element."));
+    }
+
+    // Now test customized behavior, where we allow a missing threadsafe element.
+    reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("NoThreadsafe");
+      }
+
+      @Override
+      protected boolean allowMissingThreadsafeElement() {
+        return true;
+      }
+    };
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertEquals("myapp", aeWebXml.getAppId());
+    assertEquals("1", aeWebXml.getMajorVersionId());
+    assertFalse(aeWebXml.getThreadsafeValueProvided());
+  }
+
+  public void testAutoIdPolicyWarning() {
+    AppEngineWebXmlReader reader = new AppEngineWebXmlReader(".") {
+      @Override
+      public String getFilename() {
+        return getFilenameToParse("AutoIdPolicy");
+      }
+    };
+    class WarningDetector implements Filter {
+      boolean warned = false;
+
+      @Override public boolean isLoggable(LogRecord record) {
+        warned = warned || record.getMessage().indexOf("Legacy auto ids are deprecated") >= 0;
+        return true;
+      }
+    }
+
+    WarningDetector warningDetector = new WarningDetector();
+    Logger.getLogger(AppEngineWebXmlReader.class.getName()).setFilter(warningDetector);
+
+    AppEngineWebXml aeWebXml = reader.readAppEngineWebXml();
+    assertEquals("myapp", aeWebXml.getAppId());
+    assertEquals("1", aeWebXml.getMajorVersionId());
+    assertEquals("legacy", aeWebXml.getAutoIdPolicy());
+    assertTrue("No deprecation warning logged for legacy auto ids", warningDetector.warned);
+  }
+}

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/AppEngineWebXmlTest.java
@@ -1,0 +1,1171 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.utils.config;
+
+import static org.junit.Assert.assertNotEquals;
+
+import com.google.apphosting.utils.config.AppEngineWebXml.ScalingType;
+
+import junit.framework.TestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AppEngineWebXmlTest extends TestCase {
+
+  private static final String WHITE_SPACE = "\t \n";
+  private static final String EMPTY = "";
+  private static final String AUTOMATIC = "automatic";
+
+  public void testApiEndpointExplicit() {
+    AppEngineWebXml xml = new AppEngineWebXml();
+    xml.addApiEndpoint("foo");
+    assertTrue(xml.isApiEndpoint("foo"));
+    assertFalse(xml.isApiEndpoint("bar"));
+  }
+
+  public void testThreadsafeTracking() {
+    AppEngineWebXml xml = new AppEngineWebXml();
+    assertFalse(xml.getThreadsafeValueProvided());
+    xml.setThreadsafe(false);
+    assertTrue(xml.getThreadsafeValueProvided());
+
+    xml = new AppEngineWebXml();
+    xml.setThreadsafe(true);
+    assertTrue(xml.getThreadsafeValueProvided());
+  }
+
+  public void testStaticFileIncludeEqualsNoExpires() {
+    AppEngineWebXml.StaticFileInclude include1 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", null);
+
+    // Things should equal themselves at least.
+    assertEquals(include1, include1);
+    assertEquals(include1.hashCode(), include1.hashCode());
+    assertFalse(include1.equals(null));
+    assertFalse(include1.equals("should not be equal"));
+
+    // Things could be equal to other things.
+    AppEngineWebXml.StaticFileInclude include2 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", null);
+    assertEquals(include1, include2);
+    assertEquals(include2, include1);
+    assertEquals(include1.hashCode(), include2.hashCode());
+
+    // A different path should make two StaticFileInclude instances NOT equal.
+    AppEngineWebXml.StaticFileInclude include3 = new AppEngineWebXml.StaticFileInclude(
+        "/moar-static-files/*", null);
+    assertFalse(include1.equals(include3));
+    assertFalse(include3.equals(include1));
+    // Hash codes being equal is just "almost certainly" wrong (as opposed to definitely wrong).
+    assertTrue(include1.hashCode() != include3.hashCode());
+
+    // null pattern
+    AppEngineWebXml.StaticFileInclude include4 = new AppEngineWebXml.StaticFileInclude(null, null);
+    assertFalse(include1.equals(include4));
+    assertFalse(include4.equals(include1));
+    // Hash codes being equal is just "almost certainly" wrong (as opposed to definitely wrong).
+    assertTrue(include1.hashCode() != include4.hashCode());
+
+    // Different HTTP headers should make two StaticFileIncludes not equal.
+    include2.getHttpHeaders().put("Name", "value");
+    assertFalse(include1.equals(include2));
+    assertFalse(include2.equals(include1));
+    assertTrue(include1.hashCode() != include2.hashCode());
+
+    // StaticFileIncludes can have HTTP headers and still be equal.
+    include1.getHttpHeaders().put("Name", "value");
+    assertEquals(include1, include2);
+    assertEquals(include2, include1);
+    assertEquals(include1.hashCode(), include2.hashCode());
+  }
+
+  public void testStaticFileIncludeEqualsWithExpires() {
+    String expiration = "7d";
+    AppEngineWebXml.StaticFileInclude include1 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", expiration);
+    AppEngineWebXml.StaticFileInclude include2 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", expiration);
+
+    // Things should equal themselves at least.
+    assertEquals(include1, include1);
+    assertEquals(include1.hashCode(), include1.hashCode());
+
+    // Things could be equal to other things.
+    assertEquals(include1, include2);
+    assertEquals(include2, include1);
+    assertEquals(include1.hashCode(), include2.hashCode());
+
+    // A different expiration should make two StaticFileInclude instances NOT equal.
+    AppEngineWebXml.StaticFileInclude include3 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", "10s");
+    assertFalse(include1.equals(include3));
+    assertFalse(include3.equals(include1));
+    assertTrue(include1.hashCode() != include3.hashCode());
+
+    // A different expiration should make two StaticFileInclude instances NOT equal.
+    AppEngineWebXml.StaticFileInclude include4 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", null);
+    assertFalse(include1.equals(include4));
+    assertFalse(include4.equals(include1));
+    assertTrue(include1.hashCode() != include4.hashCode());
+  }
+
+  public void testStaticFileIncludeHttpHeaderOrderPreserved() {
+    AppEngineWebXml.StaticFileInclude include1 = new AppEngineWebXml.StaticFileInclude(
+        "/static-files/*", null);
+    Map<String, String> httpHeaders = include1.getHttpHeaders();
+    httpHeaders.put("foo", "1");
+    httpHeaders.put("bar", "2");
+    Map<String, String> expected = new HashMap<>();
+    expected.put("foo", "1");
+    expected.put("bar", "2");
+    assertEquals(expected, httpHeaders);
+  }
+
+  public void testPrioritySpecifierEntryEquals() {
+    AppEngineWebXml.PrioritySpecifierEntry entry1 = new AppEngineWebXml.PrioritySpecifierEntry();
+    AppEngineWebXml.PrioritySpecifierEntry entry2 = new AppEngineWebXml.PrioritySpecifierEntry();
+    assertEquals(entry1, entry2);
+    assertNotNull(entry1);
+    entry1.setFilename("mailapi.jar");
+    assertNotEquals(entry1, entry2);
+    entry2.setFilename("mailapi.jar");
+    assertEquals(entry1, entry2);
+    entry1.setPriority("1.0");
+    assertNotEquals(entry1, entry2);
+    entry2.setPriority("1.0");
+    assertEquals(entry1, entry2);
+  }
+
+
+  public void testPrioritySpecifierEntry() {
+    AppEngineWebXml.PrioritySpecifierEntry entry = new AppEngineWebXml.PrioritySpecifierEntry();
+    assertEquals(1.0d, entry.getPriorityValue());
+    assertNull(entry.getPriority());
+    entry.setFilename("mailapi.jar");
+    try {
+      entry.setFilename("another.jar");
+      fail();
+    } catch (AppEngineConfigException e) {
+      // OK
+    }
+  }
+
+  public void testClassLoaderConfigEquals() {
+    AppEngineWebXml.PrioritySpecifierEntry ps = new AppEngineWebXml.PrioritySpecifierEntry();
+    ps.setFilename("mailapi.jar");
+
+    AppEngineWebXml.ClassLoaderConfig config1 = new AppEngineWebXml.ClassLoaderConfig();
+    AppEngineWebXml.ClassLoaderConfig config2 = new AppEngineWebXml.ClassLoaderConfig();
+    assertEquals(config1, config2);
+    assertNotNull(config1);
+    config1.add(ps);
+    assertNotEquals(config1, config2);
+    config2.add(ps);
+    assertEquals(config1, config2);
+    assertEquals(1, config1.getEntries().size());
+    assertEquals(ps, config1.getEntries().get(0));
+
+    AppEngineWebXml xml1 = new AppEngineWebXml();
+    AppEngineWebXml xml2 = new AppEngineWebXml();
+    xml1.setClassLoaderConfig(config1);
+    assertNotEquals(xml1, xml2);
+    xml2.setClassLoaderConfig(config1);
+    assertEquals(xml1, xml2);
+  }
+
+  public void testClassLoaderConfigToStringAndHash() {
+    AppEngineWebXml.PrioritySpecifierEntry ps = new AppEngineWebXml.PrioritySpecifierEntry();
+    ps.setFilename("mailapi.jar");
+    AppEngineWebXml.ClassLoaderConfig config = new AppEngineWebXml.ClassLoaderConfig();
+    config.add(ps);
+    AppEngineWebXml xml = new AppEngineWebXml();
+    int hash = xml.hashCode();
+    String str = xml.toString();
+    xml.setClassLoaderConfig(config);
+    assertNotEquals(str, xml.toString());
+    assertNotEquals(hash, xml.hashCode());
+  }
+
+  public void testInstanceClass() {
+    AppEngineWebXml xml = new AppEngineWebXml();
+    xml.setInstanceClass(WHITE_SPACE);
+    assertNull(xml.getInstanceClass());
+    xml.setInstanceClass(EMPTY);
+    assertNull(xml.getInstanceClass());
+    xml.setInstanceClass("F8");
+    assertEquals("F8", xml.getInstanceClass());
+    xml.setInstanceClass("d4");
+    assertEquals("d4", xml.getInstanceClass());
+    xml.setInstanceClass(null);
+    assertNull(xml.getInstanceClass());
+  }
+
+  public void testAutomaticScaling_setMinPendingLatency() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    settings.setMinPendingLatency(WHITE_SPACE);
+    assertNull(settings.getMinPendingLatency());
+    settings.setMinPendingLatency(EMPTY);
+    assertNull(settings.getMinPendingLatency());
+    assertTrue(settings.isEmpty());
+    settings.setMinPendingLatency(AUTOMATIC);
+    assertEquals(AUTOMATIC, settings.getMinPendingLatency());
+    assertFalse(settings.isEmpty());
+    settings.setMinPendingLatency(null);
+    assertNull(settings.getMinPendingLatency());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setMaxPendingLatency() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    settings.setMaxPendingLatency(WHITE_SPACE);
+    assertNull(settings.getMaxPendingLatency());
+    settings.setMaxPendingLatency(EMPTY);
+    assertNull(settings.getMaxPendingLatency());
+    assertTrue(settings.isEmpty());
+    settings.setMaxPendingLatency(AUTOMATIC);
+    assertEquals(AUTOMATIC, settings.getMaxPendingLatency());
+    assertFalse(settings.isEmpty());
+    settings.setMaxPendingLatency(null);
+    assertNull(settings.getMaxPendingLatency());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setMinIdleInstances() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    settings.setMinIdleInstances(WHITE_SPACE);
+    assertNull(settings.getMinIdleInstances());
+    settings.setMinIdleInstances(EMPTY);
+    assertNull(settings.getMinIdleInstances());
+    assertTrue(settings.isEmpty());
+    settings.setMinIdleInstances(AUTOMATIC);
+    assertEquals(AUTOMATIC, settings.getMinIdleInstances());
+    assertFalse(settings.isEmpty());
+    settings.setMinIdleInstances(null);
+    assertNull(settings.getMinIdleInstances());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setMaxIdleInstances() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    settings.setMaxIdleInstances(WHITE_SPACE);
+    assertNull(settings.getMaxIdleInstances());
+    settings.setMaxIdleInstances(EMPTY);
+    assertNull(settings.getMaxIdleInstances());
+    assertTrue(settings.isEmpty());
+    settings.setMaxIdleInstances(AUTOMATIC);
+    assertEquals(AUTOMATIC, settings.getMaxIdleInstances());
+    assertFalse(settings.isEmpty());
+    settings.setMaxIdleInstances(null);
+    assertNull(settings.getMaxIdleInstances());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setMinNumInstances() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    assertTrue(settings.isEmpty());
+
+    settings.setMinNumInstances(null);
+    assertNull(settings.getMinNumInstances());
+    assertTrue(settings.isEmpty());
+
+    settings.setMinNumInstances(10);
+    assertEquals(10, settings.getMinNumInstances().intValue());
+    assertFalse(settings.isEmpty());
+
+    settings.setMinNumInstances(null);
+    assertNull(settings.getMinNumInstances());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setMaxNumInstances() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    assertTrue(settings.isEmpty());
+
+    settings.setMaxNumInstances(null);
+    assertNull(settings.getMaxNumInstances());
+    assertTrue(settings.isEmpty());
+
+    settings.setMaxNumInstances(10);
+    assertEquals(10, settings.getMaxNumInstances().intValue());
+    assertFalse(settings.isEmpty());
+
+    settings.setMaxNumInstances(null);
+    assertNull(settings.getMaxNumInstances());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setCoolDownPeriodSec() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    assertTrue(settings.isEmpty());
+
+    settings.setCoolDownPeriodSec(null);
+    assertNull(settings.getCoolDownPeriodSec());
+    assertTrue(settings.isEmpty());
+
+    settings.setCoolDownPeriodSec(10);
+    assertEquals(10, settings.getCoolDownPeriodSec().intValue());
+    assertFalse(settings.isEmpty());
+
+    settings.setCoolDownPeriodSec(null);
+    assertNull(settings.getCoolDownPeriodSec());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_setCpuUtilization() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    assertTrue(settings.isEmpty());
+
+    settings.setCpuUtilization(null);
+    assertNull(settings.getCpuUtilization());
+    assertTrue(settings.isEmpty());
+
+    AppEngineWebXml.CpuUtilization expectedCpuUtil = new AppEngineWebXml.CpuUtilization();
+    expectedCpuUtil.setTargetUtilization(0.8);
+    expectedCpuUtil.setAggregationWindowLengthSec(10);
+    settings.setCpuUtilization(expectedCpuUtil);
+    AppEngineWebXml.CpuUtilization cpuUtil = settings.getCpuUtilization();
+    assertEquals(expectedCpuUtil.getTargetUtilization(), cpuUtil.getTargetUtilization());
+    assertEquals(expectedCpuUtil.getAggregationWindowLengthSec(),
+        cpuUtil.getAggregationWindowLengthSec());
+    assertFalse(settings.isEmpty());
+
+    settings.setCpuUtilization(null);
+    assertNull(settings.getCpuUtilization());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testAutomaticScaling_hashCode() {
+    AppEngineWebXml.AutomaticScaling settings1 = new AppEngineWebXml.AutomaticScaling();
+    AppEngineWebXml.AutomaticScaling settings2 = new AppEngineWebXml.AutomaticScaling();
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setMinIdleInstances(AUTOMATIC);
+    settings2.setMinIdleInstances(AUTOMATIC);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setMaxIdleInstances("10");
+    settings2.setMaxIdleInstances("10");
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setMinPendingLatency("1s");
+    settings2.setMinPendingLatency("1s");
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setMaxPendingLatency("1.2s");
+    settings2.setMaxPendingLatency("1.2s");
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setMinNumInstances(11);
+    settings2.setMinNumInstances(11);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setMaxNumInstances(22);
+    settings2.setMaxNumInstances(22);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setCoolDownPeriodSec(33);
+    settings2.setCoolDownPeriodSec(33);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    AppEngineWebXml.CpuUtilization cpuUtil = new AppEngineWebXml.CpuUtilization();
+    cpuUtil.setTargetUtilization(0.25);
+    cpuUtil.setAggregationWindowLengthSec(49);
+
+    settings1.setCpuUtilization(cpuUtil);
+    settings2.setCpuUtilization(cpuUtil);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+  }
+
+  public void testAutomaticScaling_equals() {
+    AppEngineWebXml.AutomaticScaling settings1 = new AppEngineWebXml.AutomaticScaling();
+    AppEngineWebXml.AutomaticScaling settings2 = new AppEngineWebXml.AutomaticScaling();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setMinIdleInstances(AUTOMATIC);
+    assertNotEquals(settings1, settings2);
+    settings2.setMinIdleInstances(AUTOMATIC);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setMaxIdleInstances("1ms");
+    assertNotEquals(settings1, settings2);
+    settings2.setMaxIdleInstances("1ms");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setMinPendingLatency("1s");
+    assertNotEquals(settings1, settings2);
+    settings2.setMinPendingLatency("1s");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setMaxPendingLatency("1.2s");
+    assertNotEquals(settings1, settings2);
+    settings2.setMaxPendingLatency("1.2s");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setMinNumInstances(5);
+    assertNotEquals(settings1, settings2);
+    settings2.setMinNumInstances(5);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setMaxNumInstances(10);
+    assertNotEquals(settings1, settings2);
+    settings2.setMaxNumInstances(10);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setCoolDownPeriodSec(18);
+    assertNotEquals(settings1, settings2);
+    settings2.setCoolDownPeriodSec(18);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    AppEngineWebXml.CpuUtilization cpuUtil = new AppEngineWebXml.CpuUtilization();
+    cpuUtil.setTargetUtilization(0.8);
+    cpuUtil.setAggregationWindowLengthSec(25);
+    settings1.setCpuUtilization(cpuUtil);
+    assertNotEquals(settings1, settings2);
+    settings2.setCpuUtilization(cpuUtil);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testAutomaticScaling_toString() {
+    AppEngineWebXml.AutomaticScaling settings = new AppEngineWebXml.AutomaticScaling();
+    assertEquals("AutomaticScaling [minPendingLatency=null, maxPendingLatency=null, "
+            + "minIdleInstances=null, maxIdleInstances=null, maxConcurrentRequests=null, "
+            + "minNumInstances=null, maxNumInstances=null, coolDownPeriodSec=null, "
+            + "cpuUtilization=null, "
+            + "targetNetworkSentBytesPerSec=null, targetNetworkSentPacketsPerSec=null, "
+            + "targetNetworkReceivedBytesPerSec=null, targetNetworkReceivedPacketsPerSec=null, "
+            + "targetDiskWriteBytesPerSec=null, targetDiskWriteOpsPerSec=null, "
+            + "targetDiskReadBytesPerSec=null, targetDiskReadOpsPerSec=null, "
+            + "targetRequestCountPerSec=null, targetConcurrentRequests=null"
+            + "]",
+        settings.toString());
+    settings.setMinIdleInstances(AUTOMATIC);
+    assertTrue(settings.toString().contains("minIdleInstances=automatic"));
+    settings.setMaxIdleInstances("1ms");
+    assertTrue(settings.toString().contains("maxIdleInstances=1ms"));
+    settings.setMinPendingLatency("1s");
+    assertTrue(settings.toString().contains("minPendingLatency=1s"));
+    settings.setMaxPendingLatency("1.2s");
+    assertTrue(settings.toString().contains("maxPendingLatency=1.2s"));
+    settings.setMaxConcurrentRequests("20");
+    assertTrue(settings.toString().contains("maxConcurrentRequests=20"));
+    settings.setMinNumInstances(1);
+    assertTrue(settings.toString().contains("minNumInstances=1"));
+    settings.setMaxNumInstances(5);
+    assertTrue(settings.toString().contains("maxNumInstances=5"));
+    settings.setCoolDownPeriodSec(10);
+    assertTrue(settings.toString().contains("coolDownPeriodSec=10"));
+
+    AppEngineWebXml.CpuUtilization cpuUtil = new AppEngineWebXml.CpuUtilization();
+    cpuUtil.setTargetUtilization(0.8);
+    cpuUtil.setAggregationWindowLengthSec(25);
+    settings.setCpuUtilization(cpuUtil);
+    assertTrue(settings.toString().contains(
+        "cpuUtilization=CpuUtilization [targetUtilization=0.8, aggregationWindowLengthSec=25]"));
+
+    settings.setTargetNetworkSentBytesPerSec(13);
+    assertTrue(settings.toString().contains("targetNetworkSentBytesPerSec=13"));
+    settings.setTargetNetworkSentPacketsPerSec(14);
+    assertTrue(settings.toString().contains("targetNetworkSentPacketsPerSec=14"));
+    settings.setTargetNetworkReceivedBytesPerSec(15);
+    assertTrue(settings.toString().contains("targetNetworkReceivedBytesPerSec=15"));
+    settings.setTargetNetworkReceivedPacketsPerSec(16);
+    assertTrue(settings.toString().contains("targetNetworkReceivedPacketsPerSec=16"));
+    settings.setTargetDiskWriteBytesPerSec(17);
+    assertTrue(settings.toString().contains("targetDiskWriteBytesPerSec=17"));
+    settings.setTargetDiskWriteOpsPerSec(18);
+    assertTrue(settings.toString().contains("targetDiskWriteOpsPerSec=18"));
+    settings.setTargetDiskReadBytesPerSec(19);
+    assertTrue(settings.toString().contains("targetDiskReadBytesPerSec=19"));
+    settings.setTargetDiskReadOpsPerSec(20);
+    assertTrue(settings.toString().contains("targetDiskReadOpsPerSec=20"));
+    settings.setTargetRequestCountPerSec(21);
+    assertTrue(settings.toString().contains("targetRequestCountPerSec=21"));
+    settings.setTargetConcurrentRequests(22);
+    assertTrue(settings.toString().contains("targetConcurrentRequests=22"));
+  }
+
+  public void testCpuUtilization_setTargetUtilization() {
+    AppEngineWebXml.CpuUtilization settings = new AppEngineWebXml.CpuUtilization();
+    assertTrue(settings.isEmpty());
+
+    settings.setTargetUtilization(null);
+    assertNull(settings.getTargetUtilization());
+    assertTrue(settings.isEmpty());
+
+    settings.setTargetUtilization(10.0);
+    assertEquals(10, settings.getTargetUtilization().intValue());
+    assertFalse(settings.isEmpty());
+
+    settings.setTargetUtilization(null);
+    assertNull(settings.getTargetUtilization());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testCpuUtilization_setAggregationWindowLengthSec() {
+    AppEngineWebXml.CpuUtilization settings = new AppEngineWebXml.CpuUtilization();
+    assertTrue(settings.isEmpty());
+
+    settings.setAggregationWindowLengthSec(null);
+    assertNull(settings.getAggregationWindowLengthSec());
+    assertTrue(settings.isEmpty());
+
+    settings.setAggregationWindowLengthSec(10);
+    assertEquals(10, settings.getAggregationWindowLengthSec().intValue());
+    assertFalse(settings.isEmpty());
+
+    settings.setAggregationWindowLengthSec(null);
+    assertNull(settings.getAggregationWindowLengthSec());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testCpuUtilization_hashCode() {
+    AppEngineWebXml.CpuUtilization settings1 = new AppEngineWebXml.CpuUtilization();
+    AppEngineWebXml.CpuUtilization settings2 = new AppEngineWebXml.CpuUtilization();
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setTargetUtilization(0.5);
+    settings2.setTargetUtilization(0.5);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setAggregationWindowLengthSec(10);
+    settings2.setAggregationWindowLengthSec(10);
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+  }
+
+  public void testCpuUtilization_equals() {
+    AppEngineWebXml.CpuUtilization settings1 = new AppEngineWebXml.CpuUtilization();
+    AppEngineWebXml.CpuUtilization settings2 = new AppEngineWebXml.CpuUtilization();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setTargetUtilization(0.5);
+    assertNotEquals(settings1, settings2);
+    settings2.setTargetUtilization(0.5);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setAggregationWindowLengthSec(10);
+    assertNotEquals(settings1, settings2);
+    settings2.setAggregationWindowLengthSec(10);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testCpuUtilization_toString() {
+    AppEngineWebXml.CpuUtilization settings = new AppEngineWebXml.CpuUtilization();
+    assertEquals("CpuUtilization [targetUtilization=null, aggregationWindowLengthSec=null]",
+        settings.toString());
+
+    settings.setTargetUtilization(0.5);
+    assertEquals("CpuUtilization [targetUtilization=0.5, aggregationWindowLengthSec=null]",
+        settings.toString());
+
+    settings.setAggregationWindowLengthSec(10);
+    assertEquals("CpuUtilization [targetUtilization=0.5, aggregationWindowLengthSec=10]",
+        settings.toString());
+  }
+
+  public void testManualScaling_setInstances() {
+    AppEngineWebXml.ManualScaling settings = new AppEngineWebXml.ManualScaling();
+    settings.setInstances(WHITE_SPACE);
+    assertNull(settings.getInstances());
+    settings.setInstances(EMPTY);
+    assertNull(settings.getInstances());
+    assertTrue(settings.isEmpty());
+    settings.setInstances("10");
+    assertEquals("10", settings.getInstances());
+    assertFalse(settings.isEmpty());
+    settings.setInstances(null);
+    assertNull(settings.getInstances());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testManualScaling_hashCode() {
+    AppEngineWebXml.ManualScaling settings1 = new AppEngineWebXml.ManualScaling();
+    AppEngineWebXml.ManualScaling settings2 = new AppEngineWebXml.ManualScaling();
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setInstances("20");
+    settings2.setInstances(settings1.getInstances());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+  }
+
+  public void testManualScaling_equals() {
+    AppEngineWebXml.ManualScaling settings1 = new AppEngineWebXml.ManualScaling();
+    AppEngineWebXml.ManualScaling settings2 = new AppEngineWebXml.ManualScaling();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setInstances("30");
+    assertNotEquals(settings1, settings2);
+    settings1.setInstances("");
+    assertEquals(settings1, settings2);
+    settings1.setInstances("25");
+    assertNotEquals(settings1, settings2);
+    settings2.setInstances(settings1.getInstances());
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testManualScaling_toString() {
+    AppEngineWebXml.ManualScaling settings = new AppEngineWebXml.ManualScaling();
+    assertEquals("ManualScaling [instances=null]", settings.toString());
+    settings.setInstances("30");
+    assertEquals("ManualScaling [instances=30]", settings.toString());
+  }
+
+  public void testBasicScaling_setMaxInstances() {
+    AppEngineWebXml.BasicScaling settings = new AppEngineWebXml.BasicScaling();
+    settings.setMaxInstances(WHITE_SPACE);
+    assertNull(settings.getMaxInstances());
+    settings.setMaxInstances(EMPTY);
+    assertNull(settings.getMaxInstances());
+    assertTrue(settings.isEmpty());
+    settings.setMaxInstances("10");
+    assertEquals("10", settings.getMaxInstances());
+    assertFalse(settings.isEmpty());
+    settings.setMaxInstances(null);
+    assertNull(settings.getMaxInstances());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testBasicScaling_setIdleTimeout() {
+    AppEngineWebXml.BasicScaling settings = new AppEngineWebXml.BasicScaling();
+    settings.setIdleTimeout(WHITE_SPACE);
+    assertNull(settings.getIdleTimeout());
+    settings.setIdleTimeout(EMPTY);
+    assertNull(settings.getIdleTimeout());
+    assertTrue(settings.isEmpty());
+    settings.setIdleTimeout("10m");
+    assertEquals("10m", settings.getIdleTimeout());
+    assertFalse(settings.isEmpty());
+    settings.setIdleTimeout(null);
+    assertNull(settings.getIdleTimeout());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testBasicScaling_hashCode() {
+    AppEngineWebXml.BasicScaling settings1 = new AppEngineWebXml.BasicScaling();
+    AppEngineWebXml.BasicScaling settings2 = new AppEngineWebXml.BasicScaling();
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setMaxInstances("20");
+    settings2.setMaxInstances(settings1.getMaxInstances());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+    settings1.setIdleTimeout("20m");
+    settings2.setIdleTimeout(settings1.getIdleTimeout());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+  }
+
+  public void testBasicScaling_equals() {
+    AppEngineWebXml.BasicScaling settings1 = new AppEngineWebXml.BasicScaling();
+    AppEngineWebXml.BasicScaling settings2 = new AppEngineWebXml.BasicScaling();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setMaxInstances("30");
+    assertNotEquals(settings1, settings2);
+    settings1.setMaxInstances("");
+    assertEquals(settings1, settings2);
+    settings1.setMaxInstances("25");
+    assertNotEquals(settings1, settings2);
+    settings2.setMaxInstances(settings1.getMaxInstances());
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+    settings1.setIdleTimeout("30m");
+    assertNotEquals(settings1, settings2);
+    settings1.setIdleTimeout("");
+    assertEquals(settings1, settings2);
+    settings1.setIdleTimeout("25m");
+    assertNotEquals(settings1, settings2);
+    settings2.setIdleTimeout(settings1.getIdleTimeout());
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testBasicScaling_toString() {
+    AppEngineWebXml.BasicScaling settings = new AppEngineWebXml.BasicScaling();
+    assertEquals("BasicScaling [maxInstances=null, idleTimeout=null]", settings.toString());
+    settings.setIdleTimeout("30m");
+    assertEquals("BasicScaling [maxInstances=null, idleTimeout=30m]", settings.toString());
+    settings.setMaxInstances("30");
+    assertEquals("BasicScaling [maxInstances=30, idleTimeout=30m]", settings.toString());
+  }
+
+  public void testHealthCheck_setEnableHealthCheck() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    assertTrue(settings.getEnableHealthCheck());
+
+    settings.setEnableHealthCheck(false);
+    assertFalse(settings.getEnableHealthCheck());
+
+    settings.setEnableHealthCheck(true);
+    assertTrue(settings.getEnableHealthCheck());
+  }
+
+  public void testHealthCheck_setCheckIntervalSec() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    assertTrue(settings.isEmpty());
+    settings.setCheckIntervalSec(null);
+    assertNull(settings.getCheckIntervalSec());
+    assertTrue(settings.isEmpty());
+    settings.setCheckIntervalSec(10);
+    assertEquals(10, settings.getCheckIntervalSec().intValue());
+    assertFalse(settings.isEmpty());
+    settings.setCheckIntervalSec(null);
+    assertNull(settings.getCheckIntervalSec());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testHealthCheck_setTimeoutSec() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    assertTrue(settings.isEmpty());
+    settings.setTimeoutSec(null);
+    assertNull(settings.getTimeoutSec());
+    assertTrue(settings.isEmpty());
+    settings.setTimeoutSec(10);
+    assertEquals(10, settings.getTimeoutSec().intValue());
+    assertFalse(settings.isEmpty());
+    settings.setTimeoutSec(null);
+    assertNull(settings.getTimeoutSec());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testHealthCheck_setUnhealthyThreshold() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    assertTrue(settings.isEmpty());
+    settings.setUnhealthyThreshold(null);
+    assertNull(settings.getUnhealthyThreshold());
+    assertTrue(settings.isEmpty());
+    settings.setUnhealthyThreshold(10);
+    assertEquals(10, settings.getUnhealthyThreshold().intValue());
+    assertFalse(settings.isEmpty());
+    settings.setUnhealthyThreshold(null);
+    assertNull(settings.getUnhealthyThreshold());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testHealthCheck_setHealthyThreshold() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    assertTrue(settings.isEmpty());
+    settings.setHealthyThreshold(null);
+    assertNull(settings.getHealthyThreshold());
+    assertTrue(settings.isEmpty());
+    settings.setHealthyThreshold(10);
+    assertEquals(10, settings.getHealthyThreshold().intValue());
+    assertFalse(settings.isEmpty());
+    settings.setHealthyThreshold(null);
+    assertNull(settings.getHealthyThreshold());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testHealthCheck_setRestartThreshold() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    assertTrue(settings.isEmpty());
+    settings.setRestartThreshold(null);
+    assertNull(settings.getRestartThreshold());
+    assertTrue(settings.isEmpty());
+    settings.setRestartThreshold(10);
+    assertEquals(10, settings.getRestartThreshold().intValue());
+    assertFalse(settings.isEmpty());
+    settings.setRestartThreshold(null);
+    assertNull(settings.getRestartThreshold());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testHealthCheck_setHost() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+    settings.setHost(WHITE_SPACE);
+    assertNull(settings.getHost());
+    assertTrue(settings.isEmpty());
+    settings.setHost(EMPTY);
+    assertNull(settings.getHost());
+    assertTrue(settings.isEmpty());
+    settings.setHost("test.com");
+    assertEquals("test.com", settings.getHost());
+    assertFalse(settings.isEmpty());
+    settings.setHost(null);
+    assertNull(settings.getHost());
+    assertTrue(settings.isEmpty());
+  }
+
+  public void testHealthCheck_hashCode() {
+    AppEngineWebXml.HealthCheck settings1 = new AppEngineWebXml.HealthCheck();
+    AppEngineWebXml.HealthCheck settings2 = new AppEngineWebXml.HealthCheck();
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setEnableHealthCheck(true);
+    settings2.setEnableHealthCheck(settings1.getEnableHealthCheck());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setEnableHealthCheck(false);
+    settings2.setEnableHealthCheck(settings1.getEnableHealthCheck());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setCheckIntervalSec(5);
+    settings2.setCheckIntervalSec(settings1.getCheckIntervalSec());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setTimeoutSec(6);
+    settings2.setTimeoutSec(settings1.getTimeoutSec());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setUnhealthyThreshold(7);
+    settings2.setUnhealthyThreshold(settings1.getUnhealthyThreshold());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setHealthyThreshold(8);
+    settings2.setHealthyThreshold(settings1.getHealthyThreshold());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setRestartThreshold(9);
+    settings2.setRestartThreshold(settings1.getRestartThreshold());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+
+    settings1.setHost("test.com");
+    settings2.setHost(settings1.getHost());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    assertEquals(settings1.hashCode(), settings1.hashCode());
+  }
+
+  public void testHealthCheck_equals() {
+    AppEngineWebXml.HealthCheck settings1 = new AppEngineWebXml.HealthCheck();
+    AppEngineWebXml.HealthCheck settings2 = new AppEngineWebXml.HealthCheck();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setEnableHealthCheck.
+    settings2.setEnableHealthCheck(true);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setEnableHealthCheck(false);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setEnableHealthCheck(false);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setCheckIntervalSec.
+    settings1.setCheckIntervalSec(null);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setCheckIntervalSec(5);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setCheckIntervalSec(5);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setTimeoutSec.
+    settings1.setTimeoutSec(null);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setTimeoutSec(6);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setTimeoutSec(6);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setUnhealthyThreshold.
+    settings1.setUnhealthyThreshold(null);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setUnhealthyThreshold(7);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setUnhealthyThreshold(7);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setHealthyThreshold.
+    settings1.setHealthyThreshold(null);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setHealthyThreshold(8);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setHealthyThreshold(8);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setRestartThreshold.
+    settings1.setRestartThreshold(null);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setRestartThreshold(9);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setRestartThreshold(9);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setHost.
+    settings1.setHost("");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    settings1.setHost("test.com");
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setHost("test.com");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testHealthCheck_toString() {
+    AppEngineWebXml.HealthCheck settings = new AppEngineWebXml.HealthCheck();
+
+    assertEquals("HealthCheck [enableHealthCheck=true, checkIntervalSec=null, "
+        + "timeoutSec=null, unhealthyThreshold=null, healthyThreshold=null, "
+        + "restartThreshold=null, host=null]", settings.toString());
+
+    settings.setEnableHealthCheck(false);
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=null, "
+        + "timeoutSec=null, unhealthyThreshold=null, healthyThreshold=null, "
+        + "restartThreshold=null, host=null]", settings.toString());
+
+    settings.setCheckIntervalSec(5);
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=5, "
+        + "timeoutSec=null, unhealthyThreshold=null, healthyThreshold=null, "
+        + "restartThreshold=null, host=null]", settings.toString());
+
+    settings.setTimeoutSec(6);
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=5, "
+        + "timeoutSec=6, unhealthyThreshold=null, healthyThreshold=null, "
+        + "restartThreshold=null, host=null]", settings.toString());
+
+    settings.setUnhealthyThreshold(7);
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=5, "
+        + "timeoutSec=6, unhealthyThreshold=7, healthyThreshold=null, "
+        + "restartThreshold=null, host=null]", settings.toString());
+
+    settings.setHealthyThreshold(8);
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=5, "
+        + "timeoutSec=6, unhealthyThreshold=7, healthyThreshold=8, "
+        + "restartThreshold=null, host=null]", settings.toString());
+
+    settings.setRestartThreshold(9);
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=5, "
+        + "timeoutSec=6, unhealthyThreshold=7, healthyThreshold=8, "
+        + "restartThreshold=9, host=null]", settings.toString());
+
+    settings.setHost("test.com");
+    assertEquals("HealthCheck [enableHealthCheck=false, checkIntervalSec=5, "
+        + "timeoutSec=6, unhealthyThreshold=7, healthyThreshold=8, "
+        + "restartThreshold=9, host=test.com]", settings.toString());
+  }
+
+  public void testResources_setCpu() {
+    AppEngineWebXml.Resources resources = new AppEngineWebXml.Resources();
+    resources.setCpu(3.1);
+    assertEquals(3.1, resources.getCpu());
+  }
+
+  public void testResources_setMemoryGb() {
+    AppEngineWebXml.Resources resources = new AppEngineWebXml.Resources();
+    resources.setMemoryGb(31.0);
+    assertEquals(31.0, resources.getMemoryGb());
+  }
+
+  public void testResources_setDiskSizeGb() {
+    AppEngineWebXml.Resources resources = new AppEngineWebXml.Resources();
+    resources.setDiskSizeGb(310);
+    assertEquals(310, resources.getDiskSizeGb());
+  }
+
+  public void testResources_hashCode() {
+    AppEngineWebXml.Resources settings1 = new AppEngineWebXml.Resources();
+    AppEngineWebXml.Resources settings2 = new AppEngineWebXml.Resources();
+
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    settings1.setCpu(3.1);
+    settings2.setCpu(settings1.getCpu());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    settings1.setMemoryGb(27.0);
+    settings2.setMemoryGb(settings1.getMemoryGb());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    settings1.setDiskSizeGb(312);
+    settings2.setDiskSizeGb(settings1.getDiskSizeGb());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+  }
+
+  public void testResources_equals() {
+    AppEngineWebXml.Resources settings1 = new AppEngineWebXml.Resources();
+    AppEngineWebXml.Resources settings2 = new AppEngineWebXml.Resources();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setCpu.
+    settings1.setCpu(3.1);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setCpu(3.1);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setMemoryGb.
+    settings1.setMemoryGb(3.1);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setMemoryGb(3.1);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setDiskSizeGb.
+    settings1.setDiskSizeGb(31);
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setDiskSizeGb(31);
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testResources_toString() {
+    AppEngineWebXml.Resources resources = new AppEngineWebXml.Resources();
+
+    assertEquals("Resources [cpu=0.0, memoryGb=0.0, "
+        + "diskSizeGb=0]", resources.toString());
+
+    resources.setCpu(1.6);
+    assertEquals("Resources [cpu=1.6, memoryGb=0.0, "
+        + "diskSizeGb=0]", resources.toString());
+
+    resources.setMemoryGb(5.0);
+    assertEquals("Resources [cpu=1.6, memoryGb=5.0, "
+        + "diskSizeGb=0]", resources.toString());
+    resources.setDiskSizeGb(60);
+    assertEquals("Resources [cpu=1.6, memoryGb=5.0, "
+        + "diskSizeGb=60]", resources.toString());
+  }
+
+  public void testNetwork_setInstanceTag() {
+    AppEngineWebXml.Network network = new AppEngineWebXml.Network();
+    network.setInstanceTag("mytag");
+    assertEquals("mytag", network.getInstanceTag());
+  }
+
+  public void testNetwork_addForwardedPort() {
+    AppEngineWebXml.Network network = new AppEngineWebXml.Network();
+    network.addForwardedPort("myport");
+    assertEquals("myport", network.getForwardedPorts().get(0));
+  }
+
+  public void testNetwork_hashCode() {
+    AppEngineWebXml.Network settings1 = new AppEngineWebXml.Network();
+    AppEngineWebXml.Network settings2 = new AppEngineWebXml.Network();
+
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    settings1.setInstanceTag("mytag");
+    settings2.setInstanceTag(settings1.getInstanceTag());
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+    settings1.addForwardedPort("myport");
+    settings2.addForwardedPort(settings1.getForwardedPorts().get(0));
+    assertEquals(settings1.hashCode(), settings2.hashCode());
+  }
+
+  public void testNetwork_equals() {
+    AppEngineWebXml.Network settings1 = new AppEngineWebXml.Network();
+    AppEngineWebXml.Network settings2 = new AppEngineWebXml.Network();
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For setInstanceTag.
+    settings1.setInstanceTag("mytag");
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.setInstanceTag("mytag");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+
+    // For addForwardedPort.
+    settings1.addForwardedPort("myport");
+    assertNotEquals(settings1, settings2);
+    assertNotEquals(settings1, settings2);
+
+    settings2.addForwardedPort("myport");
+    assertEquals(settings1, settings2);
+    assertEquals(settings1, settings1);
+  }
+
+  public void testNetwork_toString() {
+    AppEngineWebXml.Network network = new AppEngineWebXml.Network();
+
+    assertEquals("Network [forwardedPorts=[], instanceTag=null]", network.toString());
+
+    network.setInstanceTag("mytag");
+    assertEquals("Network [forwardedPorts=[], instanceTag=mytag]", network.toString());
+
+    network.addForwardedPort("myport");
+    assertEquals("Network [forwardedPorts=[myport], instanceTag=mytag]", network.toString());
+  }
+
+  public void testGetScalingType_automatic() {
+    AppEngineWebXml webXml = new AppEngineWebXml();
+    assertEquals(ScalingType.AUTOMATIC, webXml.getScalingType());
+  }
+
+  public void testGetScalingType_manual() {
+    AppEngineWebXml appEngineWebXml = new AppEngineWebXml();
+    appEngineWebXml.getManualScaling().setInstances("3");
+    assertEquals(ScalingType.MANUAL, appEngineWebXml.getScalingType());
+  }
+
+  public void testGetScalingType_basic() {
+    AppEngineWebXml appEngineWebXml = new AppEngineWebXml();
+    appEngineWebXml.getBasicScaling().setMaxInstances("3");
+    assertEquals(ScalingType.BASIC, appEngineWebXml.getScalingType());
+  }
+}

--- a/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/XmlUtilsTest.java
+++ b/appengine-managed-runtime/src/test/java/com/google/apphosting/utils/config/XmlUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.utils.config;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import junit.framework.TestCase;
+
+import org.w3c.dom.Element;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Unit Tests for {@link XmlUtils}.
+ */
+public class XmlUtilsTest extends TestCase {
+
+  private static final String VALID_XML =
+      "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n"
+          + "<a>\n"
+          + "  <b> B </b>\n"
+          + "</a>\n";
+  private static final String INVALID_XML = "<?xml version=\"1.0\" encoding=\"ut";
+
+  public void testGetText_null() {
+    Element node = mock(Element.class);
+    when(node.getTextContent()).thenReturn(null);
+    String result = XmlUtils.getText(node);
+    assertEquals("", result);
+  }
+
+  public void testGetText() {
+    Element node = mock(Element.class);
+    when(node.getTextContent()).thenReturn("aa");
+    String result = XmlUtils.getText(node);
+    assertEquals("aa", result);
+  }
+
+  public void testGetText_trim() {
+    Element node = mock(Element.class);
+    when(node.getTextContent()).thenReturn("  a a  ");
+    String result = XmlUtils.getText(node);
+    assertEquals("a a", result);
+  }
+
+  public void testParse_ValidXml() throws UnsupportedEncodingException {
+    InputStream is = new ByteArrayInputStream(VALID_XML.getBytes("ISO-8859-1"));
+    Element root = XmlUtils.parseXml(is).getDocumentElement();
+    assertNotNull(root);
+    assertEquals("a", root.getTagName());
+    Element child = XmlUtils.getOptionalChildElement(root, "b");
+    assertNotNull(child);
+    assertEquals("B", XmlUtils.getText(child));
+  }
+
+  public void testParse_invalidXml() throws UnsupportedEncodingException {
+    InputStream is = new ByteArrayInputStream(INVALID_XML.getBytes("ISO-8859-1"));
+    try {
+      XmlUtils.parseXml(is).getDocumentElement();
+      fail();
+    } catch (AppEngineConfigException e) {
+      assertEquals("Received SAXException parsing the input stream.", e.getMessage());
+    }
+  }
+
+  public void testParse_ioException() throws IOException {
+    try {
+      InputStream is = mock(InputStream.class);
+      when(is.read()).thenThrow(new IOException("Expected Exception"));
+      XmlUtils.parseXml(is).getDocumentElement();
+      fail();
+    } catch (AppEngineConfigException e) {
+      assertEquals("Received IOException parsing the input stream.", e.getMessage());
+    }
+  }
+}

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/AutoIdPolicy_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/AutoIdPolicy_appengine-web.xml
@@ -1,0 +1,6 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>myapp</application>
+  <version>1</version>
+  <threadsafe>false</threadsafe>
+  <auto-id-policy>legacy</auto-id-policy>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/ClassLoaderConfig_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/ClassLoaderConfig_appengine-web.xml
@@ -1,0 +1,15 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>myapp</application>
+  <version>1</version>
+  <threadsafe>false</threadsafe>
+  <static-files>
+    <exclude path="**/*.xml"/>
+  </static-files>
+  <resource-files>
+    <include path="**/*.xml"/>
+  </resource-files>
+  <ssl-enabled>true</ssl-enabled>
+  <class-loader-config>
+    <priority-specifier filename="mailapi.jar" priority="-1"/>
+  </class-loader-config>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/Empty_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/Empty_appengine-web.xml
@@ -1,0 +1,9 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application/>
+  <version/>
+  <threadsafe/>
+  <static-files/>
+  <resource-files/>
+  <ssl-enabled/>
+  <threadsafe/>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/Minimal_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/Minimal_appengine-web.xml
@@ -1,0 +1,5 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>myapp</application>
+  <version>1</version>
+  <threadsafe>false</threadsafe>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/NoThreadsafe_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/NoThreadsafe_appengine-web.xml
@@ -1,0 +1,4 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>myapp</application>
+  <version>1</version>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/UrlStreamHandler_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/UrlStreamHandler_appengine-web.xml
@@ -1,0 +1,6 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>myapp</application>
+  <version>1</version>
+  <threadsafe>false</threadsafe>
+  <url-stream-handler>native</url-stream-handler>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/Valid_appengine-web.xml
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/Valid_appengine-web.xml
@@ -1,0 +1,13 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>myapp</application>
+  <version>1</version>
+  <threadsafe>false</threadsafe>
+  <static-files>
+    <exclude path="**/*.xml"/>
+  </static-files>
+  <resource-files>
+    <include path="**/*.xml"/>
+  </resource-files>
+  <ssl-enabled>true</ssl-enabled>
+  <threadsafe/>
+</appengine-web-app>

--- a/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/appengine-web.xsd
+++ b/appengine-managed-runtime/src/test/resources/com/google/apphosting/utils/config/appengine-web.xsd
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://appengine.google.com/ns/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="appengine-web-app" type="ns:appengine-web-appType" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+  <xs:complexType name="env-varType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="system-propertiesType">
+    <xs:sequence>
+      <xs:element type="ns:propertyType" name="property" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="propertyType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="vm-settingsType">
+    <xs:sequence>
+      <xs:element type="ns:settingType" name="setting" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="beta-settingsType">
+    <xs:sequence>
+      <xs:element type="ns:settingType" name="setting" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="settingType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="asyncSessionPersistenceType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:boolean" name="enabled" use="required"/>
+        <xs:attribute type="xs:string" name="queue-name" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="appengine-web-appType">
+    <xs:all>
+      <xs:element type="xs:string" name="application" minOccurs="0"/>
+      <xs:element type="xs:string" name="version" minOccurs="0"/>
+      <xs:element type="xs:string" name="runtime" minOccurs="0"/>
+      <xs:element type="xs:string" name="module" minOccurs="0"/>
+      <xs:element type="xs:string" name="service" minOccurs="0"/>
+      <xs:element type="xs:string" name="instance-class" minOccurs="0"/>
+      <xs:element type="ns:automatic-scaling-type" name="automatic-scaling" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:manual-scaling-type" name="manual-scaling" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:basic-scaling-type" name="basic-scaling" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:static-filesType" name="static-files" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:resource-filesType" name="resource-files" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:system-propertiesType" name="system-properties" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:vm-settingsType" name="vm-settings" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:beta-settingsType" name="beta-settings" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:vm-health-checkType" name="vm-health-check" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:vm-health-checkType" name="health-check" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:resources-type" name="resources" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:network-type" name="network" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:env-variablesType" name="env-variables" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="ssl-enabled" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="sessions-enabled" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:asyncSessionPersistenceType" name="async-session-persistence" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:userPermissionsType" name="user-permissions" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:string" name="public-root" minOccurs="0"/>
+      <xs:element type="ns:inboundServicesType" name="inbound-services" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="precompilation-enabled" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:admin-console" name="admin-console" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:static-error-handlers" name="static-error-handlers" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="warmup-requests-enabled" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="threadsafe" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:string" name="auto-id-policy" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="code-lock" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="vm" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:string" name="env" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:classLoaderConfigType" name="class-loader-config" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:urlStreamHandlerType" name="url-stream-handler" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:boolean" name="use-google-connector-j" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:api-configType" name="api-config" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="api-configType">
+    <xs:sequence>
+        <xs:element type="xs:string" name="endpoint-servlet-mapping-id" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="servlet-class" type="xs:string" use="required "/>
+    <xs:attribute name="url-pattern" type="xs:string"  use="required "/>
+  </xs:complexType>
+  <xs:complexType name="env-variablesType">
+    <xs:sequence>
+      <xs:element type="ns:env-varType" name="env-var" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="includeType">
+    <xs:attribute type="xs:string" name="path" use="required"/>
+  </xs:complexType>
+  <!-- Adds two things to includeType: expiration attribute, and http-header children -->
+  <xs:complexType name="staticIncludeType">
+    <xs:complexContent>
+      <xs:extension base="ns:includeType" xmlns:ns="http://appengine.google.com/ns/1.0">
+        <xs:sequence>
+          <xs:element type="ns:http-headerType" name="http-header" minOccurs="0" maxOccurs="unbounded" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+        </xs:sequence>
+        <xs:attribute type="ns:expirationType" name="expiration" use="optional" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- See RFC 2616 for what constitutes valid HTTP header names and values. -->
+  <xs:complexType name="http-headerType">
+    <xs:attribute type="xs:string" name="name" use="required"/>
+    <xs:attribute type="xs:string" name="value" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="resource-filesType">
+    <xs:sequence>
+      <xs:element type="ns:includeType" name="include" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:excludeType" name="exclude" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="automatic-scaling-type">
+    <xs:all>
+      <xs:element type="xs:string" name="min-pending-latency" minOccurs="0"/>
+      <xs:element type="xs:string" name="max-pending-latency" minOccurs="0"/>
+      <xs:element type="xs:string" name="min-idle-instances" minOccurs="0"/>
+      <xs:element type="xs:string" name="max-idle-instances" minOccurs="0"/>
+      <xs:element type="xs:string" name="max-concurrent-requests" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="min-num-instances" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="max-num-instances" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="cool-down-period-sec" minOccurs="0"/>
+      <xs:element type="ns:cpu-utilization-type" name="cpu-utilization" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:positiveInteger" name="target-network-sent-bytes-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-network-sent-packets-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-network-received-bytes-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-network-received-packets-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-disk-write-bytes-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-disk-write-ops-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-disk-read-bytes-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-disk-read-ops-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-request-count-per-sec" minOccurs="0"/>
+      <xs:element type="xs:positiveInteger" name="target-concurrent-requests" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="cpu-utilization-type">
+    <xs:all>
+      <xs:element name="target-utilization" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:decimal">
+            <xs:minExclusive value="0"/>
+            <xs:maxInclusive value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element type="xs:positiveInteger" name="aggregation-window-length-sec" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="vm-health-checkType">
+    <xs:all>
+      <xs:element type="xs:boolean" name="enable-health-check" minOccurs="0"/>
+      <xs:element type="xs:unsignedInt" name="check-interval-sec" minOccurs="0"/>
+      <xs:element type="xs:unsignedInt" name="timeout-sec" minOccurs="0"/>
+      <xs:element type="xs:unsignedInt" name="unhealthy-threshold" minOccurs="0"/>
+      <xs:element type="xs:unsignedInt" name="healthy-threshold" minOccurs="0"/>
+      <xs:element type="xs:unsignedInt" name="restart-threshold" minOccurs="0"/>
+      <xs:element type="xs:string" name="host" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="resources-type">
+    <xs:all>
+      <xs:element type="xs:double" name="cpu" minOccurs="0"/>
+      <xs:element type="xs:double" name="memory-gb" minOccurs="0"/>
+      <xs:element type="xs:unsignedInt" name="disk-size-gb" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="network-type">
+    <xs:sequence>
+      <xs:element type="xs:string" name="forwarded-port" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element type="xs:string" name="instance-tag" minOccurs="0"/>
+      <xs:element type="xs:string" name="name" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="manual-scaling-type">
+    <xs:all>
+      <xs:element type="xs:string" name="instances"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="basic-scaling-type">
+    <xs:all>
+      <xs:element type="xs:string" name="max-instances"/>
+      <xs:element type="xs:string" name="idle-timeout" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="static-filesType">
+    <xs:sequence>
+      <xs:element type="ns:staticIncludeType" name="include" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:excludeType" name="exclude" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="excludeType">
+    <xs:attribute type="xs:string" name="path" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="userPermissionsType">
+    <xs:sequence>
+      <xs:element type="ns:permissionType" name="permission" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="permissionType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="class" use="required"/>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="actions" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="inboundServicesType">
+    <xs:sequence>
+      <xs:element type="xs:string" name="service" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="expirationType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\s*(([0-9]+)([DdHhMm]|[sS]?))(\s+([0-9]+)([DdHhMm]|[sS]?))*\s*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="admin-console">
+    <xs:sequence>
+      <xs:element type="ns:admin-console-pageType" name="page" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="admin-console-pageType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="url" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="static-error-handlers">
+    <xs:sequence>
+      <xs:element type="ns:static-error-handlers-handler" name="handler" maxOccurs="unbounded" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="static-error-handlers-handler">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="file" use="required"/>
+        <xs:attribute type="xs:string" name="error-code" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="classLoaderConfigType">
+    <xs:sequence>
+      <xs:element type="ns:prioritySpecifierType" name="priority-specifier" maxOccurs="unbounded" minOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="prioritySpecifierType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="filename" use="required"/>
+        <xs:attribute type="xs:double" name="priority" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="urlStreamHandlerType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="urlfetch|native"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
Also removes a [near] duplicated method (`getBody`) in favor of `getText` in `XmlUtils`.

Note that `getText` will concatenate the text content of children nodes, whereas getBody did not.  As this method is only called by code that seeks the text of a node with no (non-comment) children, this shouldn't be a problem.