### PR TITLE
Hide app.yaml #306

### DIFF
--- a/jetty9-base/pom.xml
+++ b/jetty9-base/pom.xml
@@ -122,7 +122,7 @@
           <arguments>
             <argument>-jar</argument>
             <argument>../jetty-distribution-${jetty.version}/start.jar</argument>
-            <argument>--add-to-startd=gae,http,deploy,jsp,jstl</argument>
+            <argument>--add-to-startd=gae,http,jsp,jstl</argument>
           </arguments>
         </configuration>
       </plugin>

--- a/jetty9-base/src/main/jetty-base/etc/gae-web.xml
+++ b/jetty9-base/src/main/jetty-base/etc/gae-web.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+
+  <!-- Protect app.yaml -->
+  <Get id="protected" name="ProtectedTargets"/>
+  <Set name="ProtectedTargets">
+    <Call class="org.eclipse.jetty.util.ArrayUtil" name="addToArray">
+      <Arg><Ref refid="protected"/></Arg>
+      <Arg>/app.yaml</Arg>
+      <Arg></Arg>
+    </Call>
+  </Set>
+  
+</Configure>
+

--- a/jetty9-base/src/main/jetty-base/etc/gae.xml
+++ b/jetty9-base/src/main/jetty-base/etc/gae.xml
@@ -72,6 +72,16 @@
     </Call>
   </Ref>
 
+  <Ref refid="DeploymentManager">
+    <Call name="addLifeCycleBinding">
+      <Arg>
+        <New class="org.eclipse.jetty.deploy.bindings.GlobalWebappConfigBinding">
+          <Set name="jettyXml"><Property name="jetty.base"/>/etc/gae-web.xml</Set>
+        </New>
+      </Arg>
+    </Call>
+  </Ref>
+
   <!-- TODO remove when this has been added to jetty.xml -->
   <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="30000"/></Set>
 

--- a/jetty9-base/src/main/jetty-base/modules/gae.mod
+++ b/jetty9-base/src/main/jetty-base/modules/gae.mod
@@ -5,6 +5,7 @@
 [depend]
 resources
 server
+deploy
 
 [optional]
 

--- a/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
+++ b/jetty9-compat-base/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.HttpOutput;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.ArrayUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.log.JavaUtilLog;
 import org.eclipse.jetty.util.resource.Resource;
@@ -342,6 +343,8 @@ public class VmRuntimeWebAppContext extends WebAppContext
     getSessionHandler().setSessionManager(sessionManager);
 
     VmRuntimeInterceptor.init(appEngineWebXml);
+    
+    setProtectedTargets(ArrayUtil.addToArray(getProtectedTargets(), "/app.yaml", String.class));
   }
 
   @Override

--- a/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
+++ b/jetty9-compat-base/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkIT.java
@@ -91,6 +91,15 @@ public class VmRuntimeJettyKitchenSinkIT extends VmRuntimeTestBase {
   }
 
   /**
+   * Tests that app.yaml is protected
+   */
+  public void testAppYamlHidden() throws Exception {
+    HttpURLConnection connection = (HttpURLConnection) createUrl("/app.yaml").openConnection();
+    connection.connect();
+    assertEquals(404, connection.getResponseCode());
+  }
+  
+  /**
    * Test that the API Proxy was configured by the VmRuntimeFilter.
    */
   public void testApiProxyInstall() throws Exception {

--- a/testwebapp/src/main/webapp/app.yaml
+++ b/testwebapp/src/main/webapp/app.yaml
@@ -1,0 +1,1 @@
+# dummy app.yaml


### PR DESCRIPTION
Hide app.yaml #306

For the pure jetty image, a deployment binding is used to apply a `gae-web.xml` (name needs to be changed when other `gae` names are changed) file to every context deployed.

For compat, the protectedTarget is just directly set.
