### PR TITLE
README: Docker for Mac troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Then, you can run this App Engine flexible environment container via the Cloud S
 https://cloud.google.com/appengine/docs/flexible/java/hello-world
 
 Enjoy...
+
+## Troubleshooting
+
+If using Docker for Mac, make sure to expose the docker socket to maven:
+
+      export DOCKER_HOST=unix:///var/run/docker.sock
+
+See https://docs.docker.com/docker-for-mac/troubleshoot/#/known-issues


### PR DESCRIPTION
Maven expects to find docker at localhost:2375, but on Docker for Mac
it's at /var/run/docker.sock.