### PR TITLE
[WIP] Add support for logging based on google-cloud-logging

### DIFF
--- a/appengine-managed-runtime/pom.xml
+++ b/appengine-managed-runtime/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <appengine.api.version>1.9.40</appengine.api.version>
+    <gcloud.api.version>0.8.2-beta-SNAPSHOT</gcloud.api.version>
   </properties>
 
   <dependencies>
@@ -86,7 +87,7 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -95,6 +96,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging</artifactId>
+      <version>${gcloud.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/RequestContextScope.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/RequestContextScope.java
@@ -1,0 +1,82 @@
+package com.google.apphosting.vmruntime;/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.cloud.logging.GaeFlexLoggingEnhancer;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandler.Context;
+import org.eclipse.jetty.server.handler.ContextHandler.ContextScopeListener;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A Jetty {@link ContextScopeListener} that is called whenever
+ * a container managed thread enters or exits the scope of a context and/or request.
+ * Used to maintain {@link ThreadLocal} references to the current request and
+ * Google traceID, primarily for logging.
+ */
+public class RequestContextScope implements ContextHandler.ContextScopeListener {
+  static final Logger logger = Logger.getLogger(RequestContextScope.class.getName());
+
+  private static final String X_CLOUD_TRACE = "x-cloud-trace-context";
+  private static final ThreadLocal<Integer> contextDepth = new ThreadLocal<>();
+
+  @Override
+  public void enterScope(Context context, Request request, Object reason) {
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("enterScope " + context);
+    }
+    if (request != null) {
+      Integer depth = contextDepth.get();
+      if (depth == null || depth.intValue() == 0) {
+        depth = 1;
+        String traceId = (String) request.getAttribute(X_CLOUD_TRACE);
+        if (traceId == null) {
+          traceId = request.getHeader(X_CLOUD_TRACE);
+          if (traceId != null) {
+            int slash = traceId.indexOf('/');
+            if (slash >= 0) {
+              traceId = traceId.substring(0, slash);
+            }
+            request.setAttribute(X_CLOUD_TRACE, traceId);
+            GaeFlexLoggingEnhancer.setCurrentTraceId(traceId);
+          }
+        } else {
+          depth = depth + 1;
+        }
+        contextDepth.set(depth);
+      }
+    }
+  }
+
+  @Override
+  public void exitScope(Context context, Request request) {
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("exitScope " + context);
+    }
+    Integer depth = contextDepth.get();
+    if (depth != null) {
+      if (depth > 1) {
+        contextDepth.set(depth - 1);
+      } else {
+        contextDepth.remove();
+        GaeFlexLoggingEnhancer.setCurrentTraceId(null);
+      }
+    }
+  }
+}

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/VmRuntimeFileLogHandler.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/VmRuntimeFileLogHandler.java
@@ -86,10 +86,12 @@ public class VmRuntimeFileLogHandler extends FileHandler {
     reloadLoggingProperties(LogManager.getLogManager());
     Logger rootLogger = Logger.getLogger("");
     for (Handler handler : rootLogger.getHandlers()) {
+      System.out.println("Logging Handler Found: " + handler.getClass().getCanonicalName());
       if (handler instanceof VmRuntimeFileLogHandler) {
         return; // Already installed.
       }
     }
+    System.out.println("Adding VmRuntimeFileLogHandler");
     rootLogger.addHandler(new VmRuntimeFileLogHandler());
   }
 


### PR DESCRIPTION
I'm trying to port over the new logging mechanism to the compat runtime to be used with a custom `logging.properties` file, but not having much luck.

In my test app, I have this in `webapp\WEB-INF\logging.properties`:
```
# Set the default logging level for all loggers to INFO
.level=INFO

# Override root level
com.foo.level=FINE

# Override parent's level
com.foo.bar.level=SEVERE

handlers=com.google.cloud.logging.LoggingHandler
com.google.cloud.logging.LoggingHandler.level=FINE
com.google.cloud.logging.LoggingHandler.log=gae_app.log
com.google.cloud.logging.LoggingHandler.resourceType=gae_app
com.google.cloud.logging.LoggingHandler.enhancers=com.google.cloud.logging.GaeFlexLoggingEnhancer
com.google.cloud.logging.LoggingHandler.formatter=java.util.logging.SimpleFormatter
java.util.logging.SimpleFormatter.format=%3$s: %5$s%6$s
```

and `appengine-web.xml` has this:
```XML
<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
  <application>YOUR-PROJECT-ID</application>
  <version>YOUR-VERSION-ID</version>
  <threadsafe>true</threadsafe>
  <env>flex</env>
  <beta-settings>
    <setting name="machine_type" value="n1-standard-1"/>
    <setting name="enable_app_engine_apis" value="true"/>
  </beta-settings>
  <system-properties>
    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
  </system-properties>
</appengine-web-app>
```

@gregw This configuration doesn't seem to be working. I only see logs in the `app` stream and no sign of  `gae_app.log` in the Stackdriver Logging UI. Any thoughts?
