### PR TITLE
Fix big file handling

### DIFF
--- a/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
+++ b/appengine-jetty-managed-runtime/src/main/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeWebAppContext.java
@@ -33,6 +33,7 @@ import com.google.apphosting.utils.http.HttpRequest;
 import com.google.apphosting.utils.http.HttpResponse;
 import com.google.apphosting.utils.servlet.HttpServletRequestAdapter;
 import com.google.apphosting.utils.servlet.HttpServletResponseAdapter;
+import com.google.apphosting.vmruntime.CommitDelayingOutputStream;
 import com.google.apphosting.vmruntime.CommitDelayingResponse;
 import com.google.apphosting.vmruntime.VmApiProxyDelegate;
 import com.google.apphosting.vmruntime.VmApiProxyEnvironment;
@@ -49,8 +50,6 @@ import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.session.AbstractSessionManager;
-import org.eclipse.jetty.server.session.HashSessionManager;
-import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.ArrayUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -89,7 +88,7 @@ public class VmRuntimeWebAppContext
   };
   // constant.  If it's much larger than this we may need to
   // restructure the code a bit.
-  protected static final int MAX_RESPONSE_SIZE = 32 * 1024 * 1024;
+  protected static final int MAX_RESPONSE_SIZE = CommitDelayingOutputStream.MAX_RESPONSE_SIZE_BYTES;
 
   private final String serverInfo;
 
@@ -280,7 +279,6 @@ public class VmRuntimeWebAppContext
       String target, Request baseRequest, HttpServletRequest httpServletRequest ,
       HttpServletResponse httpServletResponse)
       throws IOException, ServletException {
-
     HttpRequest request = new HttpServletRequestAdapter(httpServletRequest);
     HttpResponse response = new HttpServletResponseAdapter(httpServletResponse);
 

--- a/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkTest.java
+++ b/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/vmruntime/jetty9/VmRuntimeJettyKitchenSinkTest.java
@@ -20,21 +20,16 @@ import com.google.apphosting.api.ApiProxy;
 import com.google.apphosting.vmruntime.VmApiProxyDelegate;
 import com.google.apphosting.vmruntime.VmApiProxyEnvironment;
 import com.google.apphosting.vmruntime.VmRuntimeUtils;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.net.HttpURLConnection;
-import java.net.URL;
-
-import java.util.Arrays;
-import java.util.List;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Misc individual Jetty9 vmengines tests.
@@ -42,46 +37,46 @@ import org.apache.commons.httpclient.methods.GetMethod;
  */
 public class VmRuntimeJettyKitchenSinkTest extends VmRuntimeTestBase {
 
-	@Override
-	protected void setUp() throws Exception {
-		appengineWebXml = "WEB-INF/sessions-disabled-appengine-web.xml";
-		File webinf = new File("./WEB-INF");
-		if (!webinf.exists() || !webinf.isDirectory()) {
-		  webinf = new File("./target/webapps/testwebapp/WEB-INF");
-		  if (!webinf.exists() || !webinf.isDirectory()) {
-		    System.err.println(webinf.getAbsolutePath());
-		    throw new IllegalStateException("Incorrect working directory "+new File(".").getAbsoluteFile().getCanonicalPath());
-		  }
-		}
+  @Override
+  protected void setUp() throws Exception {
+    appengineWebXml = "WEB-INF/sessions-disabled-appengine-web.xml";
+    File webinf = new File("./WEB-INF");
+    if (!webinf.exists() || !webinf.isDirectory()) {
+      webinf = new File("./target/webapps/testwebapp/WEB-INF");
+      if (!webinf.exists() || !webinf.isDirectory()) {
+        System.err.println(webinf.getAbsolutePath());
+        throw new IllegalStateException("Incorrect working directory " + new File(".").getAbsoluteFile().getCanonicalPath());
+      }
+    }
 
-        File small = new File(webinf.getParentFile(),"small.txt");
-        if (!small.exists()) {
-          Writer out = new OutputStreamWriter(new FileOutputStream(small));
-          out.write("zero\n");
-          out.write("one\n");
-          out.write("two\n");
-          out.close();
-        }
-          
-		File big = new File(webinf.getParentFile(),"big.txt");
-		if (!big.exists())  {
-          Writer out = new OutputStreamWriter(new FileOutputStream(big));
-          for (int i = 0; i < 4096 ; i++) {
-            out.write(Integer.toString(i));
-            out.write("\n");
-          }
-          out.close();
-		}
+    File small = new File(webinf.getParentFile(), "small.txt");
+    if (!small.exists()) {
+      Writer out = new OutputStreamWriter(new FileOutputStream(small));
+      out.write("zero\n");
+      out.write("one\n");
+      out.write("two\n");
+      out.close();
+    }
 
-		File huge = new File(webinf.getParentFile(),"huge.txt");
-		if (!huge.exists())  {
-		  Writer out = new OutputStreamWriter(new FileOutputStream(huge));
-		  for (int i = 0; i < 16*1024*1024 ; i++) {
-		    out.write(Integer.toString(i));
-		    out.write("\n");
-		  }
-		  out.close();
-		}
+    File big = new File(webinf.getParentFile(), "big.txt");
+    if (!big.exists()) {
+      Writer out = new OutputStreamWriter(new FileOutputStream(big));
+      for (int i = 0; i < 4096; i++) {
+        out.write(Integer.toString(i));
+        out.write("\n");
+      }
+      out.close();
+    }
+
+    File huge = new File(webinf.getParentFile(), "huge.txt");
+    if (!huge.exists()) {
+      Writer out = new OutputStreamWriter(new FileOutputStream(huge));
+      for (int i = 0; i < 16 * 1024 * 1024; i++) {
+        out.write(Integer.toString(i));
+        out.write("\n");
+      }
+      out.close();
+    }
 
 		super.setUp();
 	}
@@ -116,20 +111,20 @@ public class VmRuntimeJettyKitchenSinkTest extends VmRuntimeTestBase {
     String[] lines = fetchUrl(createUrl("/"));
     assertTrue(Arrays.asList(lines).contains("Hello, World!"));
   }
-  
+
   public void testSmallTxt() throws Exception {
     String[] lines = fetchUrl(createUrl("/small.txt"));
     assertEquals("zero", lines[0]);
     assertEquals("one", lines[1]);
     assertEquals("two", lines[2]);
   }
-  
+
   public void testBigTxt() throws Exception {
     String[] lines = fetchUrl(createUrl("/big.txt"));
     assertEquals("0", lines[0]);
     assertEquals("4095", lines[4095]);
   }
-  
+
   public void testHugeTxt() throws Exception {
     System.err.println("Expect: java.io.IOException: Max response size exceeded.");
     HttpURLConnection connection = (HttpURLConnection) createUrl("/huge.txt").openConnection();
@@ -156,7 +151,7 @@ public class VmRuntimeJettyKitchenSinkTest extends VmRuntimeTestBase {
     assertEquals(VmApiProxyDelegate.class.getCanonicalName(),
             ApiProxy.getDelegate().getClass().getCanonicalName());
   }
-  
+
   /**
    * Test that the thread local environment is set up on each request.
    *
@@ -227,7 +222,7 @@ public class VmRuntimeJettyKitchenSinkTest extends VmRuntimeTestBase {
     String[] lines = fetchUrl(createUrl("/_ah/warmup")); // fetchUrl() fails on non-OK return codes.
     assertEquals(0, lines.length);
   }
-  
+
   /**
    * Test that sessions are disabled. Disabling sessions means that the default HashSessionManager 
    * is being used, which keeps sessions in memory only. Enabling sessions uses the appengine SessionManager
@@ -270,13 +265,13 @@ public class VmRuntimeJettyKitchenSinkTest extends VmRuntimeTestBase {
     int httpCode = httpClient.executeMethod(get);
     assertEquals(200, httpCode);
   }
-  
+
   protected int fetchResponseCode(URL url) throws IOException {
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
     connection.connect();
     return connection.getResponseCode();
   }
-  
+
   public void testShutDown() throws Exception {
 
     int code = fetchResponseCode(createUrl("/_ah/health"));
@@ -289,5 +284,5 @@ public class VmRuntimeJettyKitchenSinkTest extends VmRuntimeTestBase {
 
     code = fetchResponseCode(createUrl("/_ah/health"));
     assertEquals(HttpServletResponse.SC_BAD_GATEWAY, code);
-  } 
+  }
 }

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/CommitDelayingOutputStream.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/CommitDelayingOutputStream.java
@@ -36,11 +36,11 @@ import javax.servlet.WriteListener;
  * might fail.
  *
  */
-class CommitDelayingOutputStream extends ServletOutputStream {
+public class CommitDelayingOutputStream extends ServletOutputStream {
   // The wrapped OutputStream is configured with an output buffer of 32 MB (see jetty9/jetty.xml).
   // 32MB is also the maximum response size allowed by AppEngine. Setting the buffer size to the
   // maximum response size ensures that no flush occurs due to full buffer.
-  static final int MAX_RESPONSE_SIZE_BYTES = 32 * 1024 * 1024;
+  public static final int MAX_RESPONSE_SIZE_BYTES = 32 * 1024 * 1024;
   private int bufferSize = MAX_RESPONSE_SIZE_BYTES;
 
   // Make sure this matches responseHeaderSize value in jetty9/jetty.xml!

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/CommitDelayingResponse.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/CommitDelayingResponse.java
@@ -77,6 +77,9 @@ public class CommitDelayingResponse extends HttpServletResponseWrapper {
    */
   public CommitDelayingResponse(HttpServletResponse response) throws IOException {
     super(response);
+    // Set the buffer size explicitly, as this ensure both that jetty's aggregate
+    // buffer is the correct size and that the commit threshhold is that size.
+    response.setBufferSize(CommitDelayingOutputStream.MAX_RESPONSE_SIZE_BYTES);
     this.output = new CommitDelayingOutputStream(super.getOutputStream());
   }
 

--- a/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/CommitDelayingResponse.java
+++ b/appengine-managed-runtime/src/main/java/com/google/apphosting/vmruntime/CommitDelayingResponse.java
@@ -78,7 +78,7 @@ public class CommitDelayingResponse extends HttpServletResponseWrapper {
   public CommitDelayingResponse(HttpServletResponse response) throws IOException {
     super(response);
     // Set the buffer size explicitly, as this ensure both that jetty's aggregate
-    // buffer is the correct size and that the commit threshhold is that size.
+    // buffer is the correct size and that the commit threshold is that size.
     response.setBufferSize(CommitDelayingOutputStream.MAX_RESPONSE_SIZE_BYTES);
     this.output = new CommitDelayingOutputStream(super.getOutputStream());
   }

--- a/gke-debian-openjdk/src/main/docker/Dockerfile
+++ b/gke-debian-openjdk/src/main/docker/Dockerfile
@@ -17,44 +17,25 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Update debian 
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
- && apt-get -q update \
- && apt-get -y -q --no-install-recommends install \
-    ca-certificates \
-    openjdk-8-jre \
+  && apt-get -q update \
+  && apt-get -y -q --no-install-recommends install \
+    ca-certificates-java=20161107'*' \
+    openjdk-8-jre-headless=8u121'-*' \
     netbase \
     wget \ 
     unzip \
  && apt-get clean \
  && rm /var/lib/apt/lists/*_*
 
-# workaround for https://bugs.debian.org/775775
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-
-# Upgrade to OpenSSL 1.0.2 (via sid)
-ADD sid.list /etc/apt/sources.list.d/
-RUN apt-get -y update \
- && apt-get -y -q --no-install-recommends install \
-    libssl1.0.2 \
-    openssl \
-# Cleanup sid references
- && rm /etc/apt/sources.list.d/sid.list \
- && apt-get -y update \
-# Cleanup apt-get temporary files
- && apt-get -y -q upgrade \
- && apt-get -y -q autoremove
-
-# Add the cloud debugger and profiler libraries
+# Add the cloud debugger libraries
 ADD https://storage.googleapis.com/cloud-debugger/appengine-java/current/cdbg_java_agent.tar.gz /opt/cdbg/
-ADD https://storage.googleapis.com/cloud-profiler/appengine-java/current/cloud_profiler_java_agent.tar.gz /opt/cprof/
-ADD ./alpn /opt/alpn
-ADD http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/@@alpn.version@@/alpn-boot-@@alpn.version@@.jar /opt/alpn/
 COPY docker-entrypoint.bash /
 COPY gke-env.bash /
 RUN tar Cxfvz /opt/cdbg /opt/cdbg/cdbg_java_agent.tar.gz --no-same-owner \
- && tar Cxfvz /opt/cprof /opt/cprof/cloud_profiler_java_agent.tar.gz --no-same-owner \
- && rm /opt/cdbg/cdbg_java_agent.tar.gz /opt/cprof/cloud_profiler_java_agent.tar.gz \
- && ln -s /opt/alpn/alpn-boot-8.1.5.v20150921.jar /opt/alpn/alpn-boot.jar \
- && chmod +x /opt/alpn/format-env-appengine-vm.sh /docker-entrypoint.bash /gke-env.bash
+ && rm /opt/cdbg/cdbg_java_agent.tar.gz \
+ && chmod +x /docker-entrypoint.bash /gke-env.bash \
+ && mkdir /var/log/app_engine \
+ && chmod go+rwx /var/log/app_engine
 
 ENTRYPOINT ["/docker-entrypoint.bash"]
 CMD ["java","-version"]

--- a/gke-debian-openjdk/src/main/docker/Dockerfile
+++ b/gke-debian-openjdk/src/main/docker/Dockerfile
@@ -17,8 +17,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Update debian 
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
-  && apt-get -q update \
-  && apt-get -y -q --no-install-recommends install \
+ && apt-get -q update \
+ && apt-get -y -q --no-install-recommends install \
     ca-certificates-java=20161107'*' \
     openjdk-8-jre-headless=8u121'-*' \
     netbase \
@@ -27,15 +27,31 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
  && apt-get clean \
  && rm /var/lib/apt/lists/*_*
 
-# Add the cloud debugger libraries
+# workaround for https://bugs.debian.org/775775
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
+# Upgrade to OpenSSL 1.0.2 (via sid)
+ADD sid.list /etc/apt/sources.list.d/
+RUN apt-get -y update \
+ && apt-get -y -q --no-install-recommends install \
+    libssl1.0.2 \
+    openssl \
+# Cleanup sid references
+ && rm /etc/apt/sources.list.d/sid.list \
+ && apt-get -y update \
+# Cleanup apt-get temporary files
+ && apt-get -y -q upgrade \
+ && apt-get -y -q autoremove
+
+# Add the cloud debugger
 ADD https://storage.googleapis.com/cloud-debugger/appengine-java/current/cdbg_java_agent.tar.gz /opt/cdbg/
+ADD ./alpn /opt/alpn
+ADD http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/@@alpn.version@@/alpn-boot-@@alpn.version@@.jar /opt/alpn/
 COPY docker-entrypoint.bash /
 COPY gke-env.bash /
 RUN tar Cxfvz /opt/cdbg /opt/cdbg/cdbg_java_agent.tar.gz --no-same-owner \
- && rm /opt/cdbg/cdbg_java_agent.tar.gz \
- && chmod +x /docker-entrypoint.bash /gke-env.bash \
- && mkdir /var/log/app_engine \
- && chmod go+rwx /var/log/app_engine
+ && ln -s /opt/alpn/alpn-boot-8.1.5.v20150921.jar /opt/alpn/alpn-boot.jar \
+ && chmod +x /opt/alpn/format-env-appengine-vm.sh /docker-entrypoint.bash /gke-env.bash
 
 ENTRYPOINT ["/docker-entrypoint.bash"]
 CMD ["java","-version"]


### PR DESCRIPTION
Set the response buffer size to the max response size.

This PR also updates the debian image to be setup the same as https://github.com/GoogleCloudPlatform/openjdk-runtime, including using openjdk-8.   This was done because the non-durable debian repositories have changed and it is not possible to build the previous image as it was.   Use of java-8 was chosen because java-7 is end-of-life and the source/target of the `maven-compiler-plugin` was already set the 1.8 in the pom!