### PR TITLE
Fix 307 error with deferred task on Flex compat

### DIFF
--- a/appengine-jetty-managed-runtime/src/main/docker/etc/webdefault.xml
+++ b/appengine-jetty-managed-runtime/src/main/docker/etc/webdefault.xml
@@ -307,15 +307,6 @@
     </web-resource-collection>
   </security-constraint>
 
-  <security-constraint>
-    <web-resource-collection>
-      <url-pattern>/_ah/queue/__deferred__</url-pattern>
-    </web-resource-collection>
-    <auth-constraint>
-      <role-name>admin</role-name>
-    </auth-constraint>
-  </security-constraint>
-  
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>
     <welcome-file>index.jsp</welcome-file>


### PR DESCRIPTION
Fix 307 error with deferred task on Flex compat by removing security constraint for deferred task, which isn't useful due to lack of user service and returns wrong errors to customers.

This is is isolated to deferred tasks. It is safe as a header (X-AppEngine-QueueName) is verified by DeferredTaskServlet before executing the task - this is a trusted header that can only be set by internal Google traffic.

Tested with a Flex app that enqueues and executes deferred tasks.